### PR TITLE
Troca de valor inicial dos items no array `aTotICMSUFDest`

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -127,7 +127,7 @@ class Make extends BaseMake
     private $cana = '';
 
     // Arrays
-    private $aTotICMSUFDest = array('vFCPUFDest' => '', 'vICMSUFDest' => '', 'vICMSUFRemet' => '');
+    private $aTotICMSUFDest = array('vFCPUFDest' => null, 'vICMSUFDest' => null, 'vICMSUFRemet' => null);
 
     /**
      * @var DOMNode[]
@@ -6324,7 +6324,7 @@ class Make extends BaseMake
             $this->total = $this->dom->createElement("total");
         }
         //ajuste de digitos dos campos totalizados
-        if ($this->aTotICMSUFDest['vICMSUFDest'] != '') {
+        if ($this->aTotICMSUFDest['vICMSUFDest'] !== null) {
             $this->aTotICMSUFDest['vICMSUFDest'] = number_format($this->aTotICMSUFDest['vICMSUFDest'], 2, '.', '');
             $this->aTotICMSUFDest['vICMSUFRemet'] = number_format($this->aTotICMSUFDest['vICMSUFRemet'], 2, '.', '');
             $this->aTotICMSUFDest['vFCPUFDest'] = number_format($this->aTotICMSUFDest['vFCPUFDest'], 2, '.', '');


### PR DESCRIPTION
- Quando > PHP 7.1 é disparado um WARNING quando se soma string vazia mais um valor númerico. `Warning: A non-numeric value encountered`