### PR TITLE
Ws de producao sobrescreve o ws de homologacao

### DIFF
--- a/src/Common/Webservices.php
+++ b/src/Common/Webservices.php
@@ -91,11 +91,12 @@ class Webservices
         $aWS = [];
         foreach ($resp->children() as $element) {
             $sigla = (string) $element->sigla;
+            $aWS[$sigla] = [];
             if (isset($element->homologacao)) {
-                $aWS[$sigla] = $this->extract($element->homologacao, 'homologacao');
+                $aWS[$sigla] += $this->extract($element->homologacao, 'homologacao');
             }
             if (isset($element->producao)) {
-                $aWS[$sigla] = $this->extract($element->producao, 'producao');
+                $aWS[$sigla] += $this->extract($element->producao, 'producao');
             }
         }
         $this->json = json_encode($aWS);

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -63,7 +63,7 @@ class Tools extends ToolsCommon
             $aXml = $xmls;
         }
         $sxml = implode("", $aXml);
-        $sxml = preg_replace("/<\?xml.*\?>/", "", $sxml);
+        $sxml = preg_replace("/<\?xml.*?\?>/", "", $sxml);
         $this->servico(
             $servico,
             $this->config->siglaUF,


### PR DESCRIPTION
Quanto testa em homologação o loop sobrescreve o conteudo ['homologacao' => ...] em $aWS[$sigla] pelo ['producao' => ...] em vez de ter os 2 mantem so o producao... 

```php
foreach ($resp->children() as $element) {
    $sigla = (string) $element->sigla;
    if (isset($element->homologacao)) {
        $aWS[$sigla] = $this->extract($element->homologacao, 'homologacao');
    }
    if (isset($element->producao)) {
        $aWS[$sigla] = $this->extract($element->producao, 'producao');
    }
}
```

Causa uma exception na linda 59 pq não possui 'homologacao' no std  
```php
return $this->std->$auto->$ambiente;
```