### PR TITLE
Adicionando suporte para o layout 3.10 da tag Pag NFCe

### DIFF
--- a/docs/Make.md
+++ b/docs/Make.md
@@ -1194,6 +1194,23 @@ e também **obrigatório para NFe (modelo 55)** a partir do layout 4.00
 | Parametro | Tipo | Descrição |
 | :--- | :---: | :--- |
 | $std | stcClass | contêm os dados dos campos, nomeados conforme manual |
+
+Versão 3.10
+
+```php
+$std = new stdClass();
+$std->tPag = '03';
+$std->vPag = 200.00; //Obs: deve ser o informado o valor total da Nota Fiscal (vPag = vNF), caso contrário a a SEFAZ irá retornar "Rejeição 767" 
+$std->CNPJ = '12345678901234';
+$std->tBand = '01';
+$std->cAut = '3333333';
+
+$std->tpIntegra = 1; //incluso na NT 2015/002
+$elem = $nfe->tagpag($std);
+```
+
+Versão 4.00
+
 ```php
 $std = new stdClass();
 $std->vTroco = null; //incluso no layout 4.00
@@ -1202,7 +1219,7 @@ $elem = $nfe->tagpag($std);
 ```
 
 ### function tagdetPag($std):DOMElement
-Node com o detalhamento da forma de pagamento **OBRIGATÓRIO para NFCe**
+Node com o detalhamento da forma de pagamento **OBRIGATÓRIO para NFCe partir do layout 4.00**
 
 | Parametro | Tipo | Descrição |
 | :--- | :---: | :--- |
@@ -1210,12 +1227,12 @@ Node com o detalhamento da forma de pagamento **OBRIGATÓRIO para NFCe**
 ```php
 $std = new stdClass();
 $std->tPag = '03';
-$std->vPag = 200.00
+$std->vPag = 200.00; //Obs: deve ser informado o valor pago pelo cliente
 $std->CNPJ = '12345678901234';
 $std->tBand = '01';
 $std->cAut = '3333333';
 
-$std->tpIntegra = 1; //incluso no layout 4.00
+$std->tpIntegra = 1; //incluso na NT 2015/002
 
 $elem = $nfe->tagdetPag($std);
 ```

--- a/src/Make.php
+++ b/src/Make.php
@@ -5974,6 +5974,14 @@ class Make
     public function tagpag($std)
     {
         $pag = $this->dom->createElement("pag");
+
+        if ($this->version == '3.10') {
+            $this->aPag[] = $pag;
+            $this->domTagPag($pag, $std);
+
+            return $pag;
+        }
+
         //incluso no layout 4.00
         $vTroco = !empty($std->vTroco) ? $std->vTroco : null;
         $this->dom->addChild(
@@ -5983,7 +5991,9 @@ class Make
             false,
             "Valor do troco"
         );
-        return $this->aPag[] = $pag;
+
+        $this->aPag[] = $pag;
+        return $pag;
     }
 
     /**
@@ -5995,6 +6005,30 @@ class Make
      */
     public function tagdetPag($std)
     {
+        $detPag = $this->dom->createElement("detPag");
+        $this->domTagPag($detPag, $std);
+
+        $n = count($this->aPag);
+        $node = $this->aPag[$n-1]->getElementsByTagName("vTroco")->item(0);
+        if (!empty($node)) {
+            $this->aPag[$n-1]->insertBefore($detPag, $node);
+        } else {
+            $this->dom->appChild($this->aPag[$n-1], $detPag, 'Falta tag "Pag"');
+        }
+        return $detPag;
+    }
+
+
+    /**
+     * Monta o DOM da tag de pagamento
+     * Utilizado em `tagpag` e `tagdetPag`
+     * Apenas para o modelo 65 NFCe
+     * @param $domPag
+     * @param stdClass $std
+     * @return DOMElement
+     */
+    private function domTagPag($domPag, $std)
+    {
         $possible = [
             'tPag',
             'vPag',
@@ -6004,24 +6038,25 @@ class Make
             'tpIntegra'
         ];
         $std = $this->equilizeParameters($std, $possible);
-        
-        $detPag = $this->dom->createElement("detPag");
+
         $this->dom->addChild(
-            $detPag,
+            $domPag,
             "tPag",
             $std->tPag,
             true,
             "Forma de pagamento"
         );
         $this->dom->addChild(
-            $detPag,
+            $domPag,
             "vPag",
             $std->vPag,
             true,
             "Valor do Pagamento"
         );
+
         if ($std->tBand != '') {
             $card = $this->dom->createElement("card");
+
             $this->dom->addChild(
                 $card,
                 "tpIntegra",
@@ -6050,16 +6085,11 @@ class Make
                 true,
                 "Número de autorização da operação cartão de crédito e/ou débito"
             );
-            $this->dom->appChild($detPag, $card, "Inclusão do node Card");
+
+            $this->dom->appChild($domPag, $card, "Inclusão do node Card");
         }
-        $n = count($this->aPag);
-        $node = $this->aPag[$n-1]->getElementsByTagName("vTroco")->item(0);
-        if (!empty($node)) {
-            $this->aPag[$n-1]->insertBefore($detPag, $node);
-        } else {
-            $this->dom->appChild($this->aPag[$n-1], $detPag, 'Falta tag "Pag"');
-        }
-        return $detPag;
+
+        return $domPag;
     }
 
     /**


### PR DESCRIPTION
- Suporte a versão 3.10 da tag de pagamento para nota fiscal modelo 65
  - Refatorado a criação do DOM da _tag_ **pag**
  - No layout 3.10 o valor da _tag_ **vPag** deve ser igual à  _tag_ **vNF** caso contrário é devolvido a resposta "767 - NFC-e com somatório dos pagamentos diferente do total da Nota Fiscal". 
  - No layout 4.00, pelo menos no ambiente homologação de SP, envio o valor pago pelo cliente + **vTroco**, e está funcionando normalmente.
  
Exemplo:

**versão 4.00**

```php
$std = new stdClass();
$std->vTroco = 43.00;

$nfe->tagpag($std);

$std = new stdClass();
$std->tPag = '01';
$std->vPag = 50.00;

$nfe->tagdetPag($std);
```

output:

```xml
<pag>
    <detPag>
        <tPag>01</tPag>
        <vPag>50.00</vPag>
    </detPag>
    <vTroco>43.00</vTroco>
</pag>
```

**versão 3.10**

```php
$std = new stdClass();
$std->tPag = '01';
$std->vPag = 7.00;

$nfe->tagpag($std);
```

output:

```xml
<pag>
    <tPag>01</tPag>
    <vPag>7.00</vPag>
</pag>
```

Referências: 

- http://www.flexdocs.com.br/guiaNFe/gerarNFe.pag.html
- http://www.flexdocs.com.br/guiaNFe/gerarNFe.pagNT2015002.html
- http://www.flexdocs.com.br/guiaNFe/gerarNFe.pag400.html
- http://www.flexdocs.com.br/guiaNFe/gerarNFe.pag400.detPag.html
- http://www.oobj.com.br/bc/article/rejei%C3%A7%C3%A3o-767-nfc-e-com-somat%C3%B3rio-dos-pagamentos-diferente-do-total-da-nota-fiscal-como-resolver-181.html