### PR TITLE
PHPUnit TestCase com PSR-1

### DIFF
--- a/tests/NFeTestCase.php
+++ b/tests/NFeTestCase.php
@@ -2,13 +2,15 @@
 
 namespace NFePHP\NFe\Tests;
 
-class NFeTestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NFeTestCase extends TestCase
 {
     public $fixturesPath = '';
     public $configJson = '';
     public $contentpfx = '';
     public $passwordpfx = '';
-    
+
     public function __construct()
     {
         $this->fixturesPath = dirname(__FILE__) . '/fixtures/';


### PR DESCRIPTION
Usei a [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) enquanto extendendo a classe `PHPUnit TestCase`. Isso irá nos ajudar quando migrarmos para o `PHPUnit 6`, que [não mais suporta _snake case namespaces_](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).