### PR TITLE
Na tag indPag, força-se a criação da tag caso o valor seja zero ("0")

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -511,7 +511,8 @@ class Make
             "indPag",
             $std->indPag,
             false,
-            $identificador . "Indicador da forma de pagamento"
+            $identificador . "Indicador da forma de pagamento",
+            true
         );
         $this->dom->addChild(
             $ide,


### PR DESCRIPTION
Olá, Roberto.  Dessa vez é uma pequena contribuição mas que me deu bastante dor de cabeça e algumas horas de trabalho perdidas. 

O grande problema é que se eu passasse para a tag indPag o valor 0 (Zero), a API não criava a tag e acabava dando erro de validação com o schema. A mensagem de erro do schema não dizia muito a respeito do problema.

`This XML is not valid. Element '{http://www.portalfiscal.inf.br/nfe}mod': This element is not expected. Expected is ( {http://www.portalfiscal.inf.br/nfe}indPag ).`

Após perceber que a tag indPag não era criada, resolvi debugar até o ponto de criação e percebi que a referida tag não estava sendo criada. Alterei a chamada do método na classe Make para que seja forçada a criação da tag. Isto resolveu o meu problema e acredito que também possa evitar que outros colegas percam seu tempo com este problema bobo.

Obrigado pela ferramenta e espero poder contribuir com mais.