### PR TITLE
[UPD] Complements::cancelRegister

### DIFF
--- a/src/Complements.php
+++ b/src/Complements.php
@@ -108,8 +108,7 @@ class Complements
         $domcanc->formatOutput = false;
         $domcanc->preserveWhiteSpace = false;
         $domcanc->loadXML($cancelamento);
-        $retEvento = $domcanc->getElementsByTagName('retEvento')->item(0);
-        $eventos = $retEvento->getElementsByTagName('infEvento');
+        $eventos = $domcanc->getElementsByTagName('infEvento');
         foreach ($eventos as $evento) {
             $cStat = $evento->getElementsByTagName('cStat')
                 ->item(0)

--- a/src/Complements.php
+++ b/src/Complements.php
@@ -108,18 +108,19 @@ class Complements
         $domcanc->formatOutput = false;
         $domcanc->preserveWhiteSpace = false;
         $domcanc->loadXML($cancelamento);
-        $eventos = $domcanc->getElementsByTagName('infEvento');
+        $eventos = $domcanc->getElementsByTagName('retEvento');
         foreach ($eventos as $evento) {
-            $cStat = $evento->getElementsByTagName('cStat')
+            $infEvento = $domcanc->getElementsByTagName('infEvento')->item(0);
+            $cStat = $infEvento->getElementsByTagName('cStat')
                 ->item(0)
                 ->nodeValue;
-            $nProt = $evento->getElementsByTagName('nProt')
+            $nProt = $infEvento->getElementsByTagName('nProt')
                 ->item(0)
                 ->nodeValue;
-            $chaveEvento = $evento->getElementsByTagName('chNFe')
+            $chaveEvento = $infEvento->getElementsByTagName('chNFe')
                 ->item(0)
                 ->nodeValue;
-            $tpEvento = $evento->getElementsByTagName('tpEvento')
+            $tpEvento = $infEvento->getElementsByTagName('tpEvento')
                 ->item(0)
                 ->nodeValue;
             if (in_array($cStat, ['135', '136', '155'])


### PR DESCRIPTION
I've done a little implementation, and now the method is able to add a cancel protocol with the response from the sefazConsultaChave method (wich maybe return multiple kind of events), that's useful when lot receipt is lost or the event is sent in duplicit.