### PR TITLE
TP integra tipo 2, para quem nao possui TEF

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -6039,8 +6039,11 @@ class Make
                 true,
                 "Valor do Pagamento"
             );
+                      
             if ($std->tBand != '') {
+                
                 $card = $this->dom->createElement("card");
+                
                 $this->dom->addChild(
                     $card,
                     "tpIntegra",
@@ -6071,6 +6074,24 @@ class Make
                 );
                 $this->dom->appChild($this->aPag[$n-1], $card, "Inclusão do node Card");
             }
+            
+            //EMISSÃO PARA EMPRESAS SEM TEF, UTILIZANDO POS OU APENAS A MAQUINETA                
+            if($std->tpIntegra == '2' && !isset($card) ){
+
+                $card = $this->dom->createElement("card");
+
+                $this->dom->addChild(
+                    $card,
+                    "tpIntegra",
+                    $std->tpIntegra,
+                    false,
+                    "Tipo de Integração para pagamento"
+                );
+                
+                $this->dom->appChild($this->aPag[$n-1], $card, "Inclusão do node Card");
+            }
+                
+            
             return $this->aPag[$n-1];
         } else {
             $detPag = $this->dom->createElement("detPag");


### PR DESCRIPTION
Para quem nao possui TEF integrado ao sistema, nao é obrigatório o envio do Codigo de autorização, como os demais campos do cartão (Bandeira, CNPJ, e cAut)
O que adicionei aqui foi a validação do tpIntegra tipo 2 como descrito no XSD: "Pagamento não integrado com o sistema de automação da empresa Ex: equipamento POS"
Para que os contribuintes emitam a nota fiscal sem o uso do código de autorização da maquineta