### PR TITLE
Não gerar exceção ao receber o cStat 302 

### DIFF
--- a/src/Complements.php
+++ b/src/Complements.php
@@ -255,7 +255,8 @@ class Complements
                     //150 Autorizado fora do prazo
                     //110 Uso Denegado
                     //205 NFe Denegada
-                    $cstatpermit = ['100', '150', '110', '205'];
+                    //302 Uso denegado por irregularidade fiscal do destinatário
+                    $cstatpermit = ['100', '150', '110', '205', '302'];
                     if (!in_array($cStat, $cstatpermit)) {
                         throw DocumentsException::wrongDocument(4, "[$cStat] $xMotivo");
                     }


### PR DESCRIPTION
Segundo a documentação [da Totvs](http://tdn.totvs.com/pages/releaseview.action?pageId=194512190) e  [da Oobj](https://www.oobj.com.br/bc/article/rejei%C3%A7%C3%A3o-302-uso-denegado-irregularidade-fiscal-do-destinat%C3%A1rio-como-resolver-28.html), as notas fiscais com o status 302 devem ser armazenadas e o destinatário deve procurar a regularização de sua inscrição estadual.

Portanto eu fiz um ajuste para permitir a execução normal do código caso o cStat seja o 302.