### PR TITLE
[upd] tag idEstrangeiro

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1125,7 +1125,7 @@ class Make
             $this->dom->addChild(
                 $this->dest,
                 "idEstrangeiro",
-                $std->idEstrangeiro,
+                Strings::replaceSpecialsChars(substr(trim($std->idEstrangeiro), 0, 50)),
                 true,
                 $identificador . "Identificação do destinatário no caso de comprador estrangeiro",
                 true


### PR DESCRIPTION
Apesar de utilizar o atributo force = true na função addChild, como o valor passado na variavel $std->idEstrangeiro poderia ser null, a api nao criava a tag vazia no xml.