### PR TITLE
Correção de falha ao validar o GTIN

### DIFF
--- a/src/Common/Gtin.php
+++ b/src/Common/Gtin.php
@@ -29,7 +29,7 @@ class Gtin
         if (!is_numeric($gtin)) {
             return false;
         }
-        $dv = (int) substr($num, -1);
+        $dv = (int) substr($gtin, -1);
         $mod = self::calcDV($gtin);
         if ($dv === $mod) {
             return true;


### PR DESCRIPTION
Bom dia.

Eu peguei um erro no método de validação do GTIN onde não existia a variável `$num`. Apenas substitui para a variável que contém o GTIN.

Att.