### PR TITLE
Novos schemas para atender a NT 2016.002 v1.60 -b

### DIFF
--- a/schemes/PL_009_V4/leiauteNFe_v4.00.xsd
+++ b/schemes/PL_009_V4/leiauteNFe_v4.00.xsd
@@ -6,6 +6,9 @@
 <!-- PL_008i -->
 <!-- PL_009-v4  alterações de esquema decorrentes da - NT2016.002 - 10/2017 -->
 <!-- PL_009-v4a  alterações de esquema decorrentes da - NT2017.001 - 10/2017 -->
+<!-- PL_009-v4a  alterações de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
+<!-- PL_009-v4a.1  correções de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
+<!-- PL_009-v4a.2  adequação do campo placa para novo padrão do Mercosul - 06/2018 -->
 
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.portalfiscal.inf.br/nfe" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:editix="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
@@ -871,8 +874,8 @@ Formato ”CFOP9999”.</xs:documentation>
 												<xs:element minOccurs="0" name="cBenef">
 													<xs:simpleType>
 														<xs:restriction base="xs:string">
-															<xs:length value="10"/>
-														</xs:restriction>
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="([!-ÿ]{8}|[!-ÿ]{10})?"/>													</xs:restriction>
 													</xs:simpleType>
 												</xs:element>
 												<xs:element minOccurs="0" name="EXTIPI">
@@ -1583,7 +1586,8 @@ N-NormalVIN</xs:documentation>
 															<xs:sequence>
 																<xs:element minOccurs="1" name="cProdANVISA">
 																	<xs:annotation>
-																		<xs:documentation>Código de Produto da ANVISA. Utilizar o número do registro do produto da Câmara de Regulação do Mercado de Medicamento – CMED.</xs:documentation>
+																		<xs:documentation>Utilizar o número do registro ANVISA
+Obs.: Para medicamento isento de registro na ANVISA, utilizar o número da decisão que o isenta, como por exemplo o número da Resolução da Diretoria Colegiada da ANVISA (RDC).</xs:documentation>
 																	</xs:annotation>
 																	<xs:simpleType>
 																		<xs:restriction base="TString">
@@ -2500,7 +2504,7 @@ A exigência do preenchimento das informações do ICMS diferido fica à critér
 																							<xs:documentation>Aliquota suportada pelo consumidor final.</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
-																					<xs:element name="vICMSSTRet" type="TDec_1302">
+																				<xs:element name="vICMSSTRet" type="TDec_1302">
 																						<xs:annotation>
 																							<xs:documentation>Valor do ICMS ST retido anteriormente</xs:documentation>
 																						</xs:annotation>
@@ -2520,6 +2524,30 @@ A exigência do preenchimento das informações do ICMS diferido fica à critér
 																					<xs:element name="vFCPSTRet" type="TDec_1302">
 																						<xs:annotation>
 																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+
+<xs:sequence minOccurs="0">
+
+<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
 																				</xs:sequence>
@@ -3375,7 +3403,32 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																						</xs:annotation>
 																					</xs:element>
 																				</xs:sequence>
-																			</xs:sequence>
+
+<xs:sequence minOccurs="0">
+
+<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			
+</xs:sequence>
 																		</xs:complexType>
 																	</xs:element>
 																	<xs:element name="ICMSSN900">
@@ -4862,17 +4915,17 @@ Substituição Tributaria;</xs:documentation>
 														</xs:restriction>
 													</xs:simpleType>
 												</xs:element>
-												<xs:element minOccurs="0" name="vOrig" type="TDec_1302Opc">
+												<xs:element minOccurs="0" name="vOrig" type="TDec_1302">
 													<xs:annotation>
 														<xs:documentation>Valor original da fatura</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="vDesc" type="TDec_1302Opc">
+												<xs:element minOccurs="0" name="vDesc" type="TDec_1302">
 													<xs:annotation>
 														<xs:documentation>Valor do desconto da fatura</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="vLiq" type="TDec_1302Opc">
+												<xs:element minOccurs="0" name="vLiq" type="TDec_1302">
 													<xs:annotation>
 														<xs:documentation>Valor líquido da fatura</xs:documentation>
 													</xs:annotation>
@@ -5391,7 +5444,7 @@ concessório</xs:documentation>
 									<xs:whiteSpace value="preserve"/>
 									<xs:minLength value="100"/>
 									<xs:maxLength value="600"/>
-									<xs:pattern value="(((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=[0-9]{3}&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})|((HTTPS?|https?)://.*\?p=[0-9]{44}\|[2]\|[1-2]\|(([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|)?(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40}))"/>
+									<xs:pattern value="(((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})|((HTTPS?|https?)://.*\?p=([0-9]{34}(1|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})|((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40}))"/>
 								</xs:restriction>
 							</xs:simpleType>
 						</xs:element>
@@ -5993,7 +6046,7 @@ alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
 				<xs:simpleType>
 					<xs:restriction base="xs:string">
 						<xs:whiteSpace value="preserve"/>
-						<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}"/>
+						<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}|[A-Z0-9]{7}"/>
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:element>

--- a/schemes/PL_009_V4/tiposBasico_v4.00.xsd
+++ b/schemes/PL_009_V4/tiposBasico_v4.00.xsd
@@ -512,7 +512,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TData">


### PR DESCRIPTION
Boa tarde, Roberto.

Estava enfrentado um problema com uma nota onde eu tomava a rejeição `905 -  Campos do grupo Fatura nao informados`. Vi que a minha tag `vDesc` em `fat` não era preenchida. Passei nulo pra ela mas eu tomava falha já no schema. Então eu vi que tivemos algumas alterações mais importantes nos schemas, incluindo o meu problema. Tomei a liberdade de atualizá-los, segundo este [link](http://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=CoNA9VIgZ3E=).

Atenciosamente.