### PR TITLE
Criação de parâmetro para ignorar erros de digest value ao adicionar os protocolos de autorização de uso das NF-e

### DIFF
--- a/src/Complements.php
+++ b/src/Complements.php
@@ -269,9 +269,7 @@ class Complements
         }
         /**
          * Em alguns casos, podem acontecer divergências de Digest Value.
-         * Normalmente este erro pode acontecer por conta da SEFAZ ao devolver os protocolos com os digest values diferentes daqueles que
-         * o contribuinte forneceu no nó de assinatura da NF-e.
-         * Para esta situação, o programador pode ignorar esta proteção, claro que por sua conta em risco.
+         * Normalmente este erro pode acontecer por conta da SEFAZ devolver nos protocolos de autorização, valores de digest diferentes daqueles que o contribuinte forneceu no nó de assinatura da NF-e.
          */
         if(!$ignore_digest_error){
             if ($digNFe !== $digProt) {

--- a/src/Complements.php
+++ b/src/Complements.php
@@ -216,7 +216,7 @@ class Complements
      * @return string
      * @throws \InvalidArgumentException
      */
-    protected static function addNFeProtocol($request, $response)
+    protected static function addNFeProtocol($request, $response, $ignore_digest_error = false)
     {
         $req = new DOMDocument('1.0', 'UTF-8');
         $req->preserveWhiteSpace = false;
@@ -267,8 +267,16 @@ class Complements
                 }
             }
         }
-        if ($digNFe !== $digProt) {
-            throw DocumentsException::wrongDocument(5, "Os digest são diferentes");
+        /**
+         * Em alguns casos, podem acontecer divergências de Digest Value.
+         * Normalmente este erro pode acontecer por conta da SEFAZ ao devolver os protocolos com os digest values diferentes daqueles que
+         * o contribuinte forneceu no nó de assinatura da NF-e.
+         * Para esta situação, o programador pode ignorar esta proteção, claro que por sua conta em risco.
+         */
+        if(!$ignore_digest_error){
+            if ($digNFe !== $digProt) {
+                throw DocumentsException::wrongDocument(5, "Os digest são diferentes");
+            }
         }
         return $req->saveXML();
     }


### PR DESCRIPTION
Bom dia, Roberto.

Ontem eu enfrentei um problema com a SEFAZ do RS onde ao emitir a NF-e e adicionar o protocolo de autorização no meu XML, as digest divergiam inexplicavelmente.

Procurei saber a respeito deste problema e meus colegas me aconselharam a tratar este tipo de problema assim como o projeto ACBr faz. Ou seja: ignorando esta verificação, salvando o protocolo mesmo assim e devolvendo o XML para o armazenamento.

Não sei se esta é a melhor solução para o problema mas como o ACBr trata este problema desta forma, acredito que não esteja tão errado assim.

Aos demais colaboradores: Já enfrentaram este tipo de problema? Dissertem um pouco sobre isto.