### PR TITLE
Tag <cEAN>

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1571,8 +1571,8 @@ class Make
         $this->stdTot->vDesc += (float) $std->vDesc;
         $this->stdTot->vOutro += (float) $std->vOutro;
         
-        $cean = !empty($std->cEAN) ? trim(strtoupper($std->cEAN)) : '';
-        $ceantrib = !empty($std->cEANTrib) ? trim(strtoupper($std->cEANTrib)) : '';
+        $cean = !empty($std->cEAN) ? trim(strtoupper($std->cEAN)) : 'SEM GTIN';
+        $ceantrib = !empty($std->cEANTrib) ? trim(strtoupper($std->cEANTrib)) : 'SEM GTIN';
         
         $identificador = 'I01 <prod> - ';
         $prod = $this->dom->createElement("prod");

--- a/storage/wsnfe_4.00_mod55.xml
+++ b/storage/wsnfe_4.00_mod55.xml
@@ -106,7 +106,7 @@
         <homologacao>
             <NfeStatusServico method="nfeStatusServicoNF" operation="NFeStatusServico4" version="4.00">https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeStatusServico4</NfeStatusServico>
             <NfeAutorizacao method="nfeAutorizacaoLote" operation="NFeAutorizacao4" version="4.00">https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeAutorizacao4</NfeAutorizacao>
-            <NfeConsultaProtocolo method="nfeConsultaNF" operation="NFeConsulta4" version="4.00">https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeConsultaProtocolo4</NfeConsultaProtocolo>
+            <NfeConsultaProtocolo method="nfeConsultaNF" operation="NFeConsultaProtocolo4" version="4.00">https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeConsultaProtocolo4</NfeConsultaProtocolo>
             <NfeInutilizacao method="nfeInutilizacaoNF" operation="NFeInutilizacao4" version="4.00">https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeInutilizacao4</NfeInutilizacao>
             <NfeRetAutorizacao method="nfeRetAutorizacaoLote" operation="NFeRetAutorizacao4" version="4.00">https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeRetAutorizacao4</NfeRetAutorizacao>
             <RecepcaoEvento method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento4" version="1.00">https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeRecepcaoEvento4</RecepcaoEvento>
@@ -115,7 +115,7 @@
         <producao>
             <NfeStatusServico method="nfeStatusServicoNF" operation="NFeStatusServico4" version="4.00">https://nfe.fazenda.mg.gov.br/nfe2/services/NFeStatusServico4</NfeStatusServico>
             <NfeAutorizacao method="nfeAutorizacaoLote" operation="NFeAutorizacao4" version="4.00">https://nfe.fazenda.mg.gov.br/nfe2/services/NFeAutorizacao4</NfeAutorizacao>
-            <NfeConsultaProtocolo method="nfeConsultaNF" operation="NFeConsulta4" version="4.00">https://nfe.fazenda.mg.gov.br/nfe2/services/NFeConsultaProtocolo4</NfeConsultaProtocolo>
+            <NfeConsultaProtocolo method="nfeConsultaNF" operation="NFeConsultaProtocolo4" version="4.00">https://nfe.fazenda.mg.gov.br/nfe2/services/NFeConsultaProtocolo4</NfeConsultaProtocolo>
             <NfeInutilizacao method="nfeInutilizacaoNF" operation="NFeInutilizacao4" version="4.00">https://nfe.fazenda.mg.gov.br/nfe2/services/NFeInutilizacao4</NfeInutilizacao>
             <NfeRetAutorizacao method="nfeRetAutorizacaoLote" operation="NFeRetAutorizacao4" version="4.00">https://nfe.fazenda.mg.gov.br/nfe2/services/NFeRetAutorizacao4</NfeRetAutorizacao>
             <RecepcaoEvento method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento4" version="1.00">https://nfe.fazenda.mg.gov.br/nfe2/services/NFeRecepcaoEvento4</RecepcaoEvento>


### PR DESCRIPTION
Seguindo a docimentação da seguinte NT:  http://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=T7PfUOHhMD4=, caso o GTIN seja enviado vazio a tag não pode mais ser e sim 'SEM GTIN'