### PR TITLE
corrige as urls de consutar QRCode para o estado do RJ

### DIFF
--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -223,10 +223,10 @@
   <UF>
     <sigla>RJ</sigla>
     <homologacao>
-       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode?</NfeConsultaQR>
+       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode</NfeConsultaQR>
     </homologacao>
     <producao>
-       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode?</NfeConsultaQR>
+       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode</NfeConsultaQR>
     </producao>
   </UF>
   <UF>


### PR DESCRIPTION
As urls não podem ter o "?" no final pois no método "get200" da classe "\Factories\QRCode" existe uma verificação para poder adicionar o "?p=" a url.
Segue abaixo:
**if (strpos($url, '?p=') === false) {
     $url = $url.'?p=';
}**

Fazendo a url ficar com 2 "??" o que gera a "Rejeição 464 Codigo de Hash no QR-Code difere do calculado"

Exemplo da url com errada:
"http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode??p=33180839417670000143650010009000101000003884|2|2|1|15B1358DC20165B597BE515A1767769E4CB67AE8"