### PR TITLE
Alteração na URL do QR Code do estado de Goiás

### DIFF
--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -108,7 +108,7 @@
        <NfeStatusServico method="nfeStatusServicoNF" operation="NFeStatusServico4" version="4.00">https://homolog.sefaz.go.gov.br/nfe/services/NFeStatusServico4</NfeStatusServico>
        <RecepcaoEvento method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento" version="1.00">https://homolog.sefaz.go.gov.br/nfe/services/NFeRecepcaoEvento4</RecepcaoEvento>
        <CscNFCe method="admCscNFCe" operation="CscNFCe" version="1.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/CscNFCe</CscNFCe>
-       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://homolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe</NfeConsultaQR>
+       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://homolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe</NfeConsultaQR>
     </homologacao>
     <producao>
        <NfeAutorizacao method="nfeAutorizacaoLote" operation="NFeAutorizacao4" version="4.00">https://nfe.sefaz.go.gov.br/nfe/services/NFeAutorizacao4</NfeAutorizacao>


### PR DESCRIPTION
A URL de consulta de NFC-e da Sefaz Goiás que é utilizado para codificar QR Code não é https e sim http. Esclarecimentos obtidos junto ao técnico de TI do estado. Testado aqui na empresa inclusive.