### PR TITLE
Alteração na URL do QR Code no estado de Goiás, na versão 4.00

### DIFF
--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -118,7 +118,7 @@
        <NfeStatusServico method="nfeStatusServicoNF" operation="NFeStatusServico4" version="4.00">https://nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4</NfeStatusServico>
        <RecepcaoEvento method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento" version="1.00">https://nfe.sefaz.go.gov.br/nfe/services/NFeRecepcaoEvento4</RecepcaoEvento>
        <CscNFCe method="admCscNFCe" operation="CscNFCe" version="1.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/CscNFCe</CscNFCe>
-       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://nfe.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe</NfeConsultaQR>
+       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://nfe.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe</NfeConsultaQR>
     </producao>
   </UF>
   <UF>


### PR DESCRIPTION
A URL de consulta do QR Code da NFC-e 4.00 no GO em produção, assim como homologação, não é https.