### PR TITLE
Testes da classe Webservices e melhoria em Tools:

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
         <!--<log type="junit" target="build/report.junit.xml"/>-->
         <!--<log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>-->
         <!--<log type="coverage-text" target="build/coverage.txt"/>-->
+        <!--<log type="coverage-text" target="php://stdout"/>-->
         <!--<log type="coverage-clover" target="build/logs/clover.xml"/>-->
     </logging>
 </phpunit>

--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -30,7 +30,6 @@ use NFePHP\NFe\Factories\Contingency;
 use NFePHP\NFe\Factories\ContingencyNFe;
 use NFePHP\NFe\Factories\Header;
 use NFePHP\NFe\Factories\QRCode;
-use SoapHeader;
 
 class Tools
 {
@@ -453,8 +452,9 @@ class Tools
      * Assembles all the necessary parameters for soap communication
      * @param string $service
      * @param string $uf
-     * @param int $tpAmb 1-Production ou 2-Testing
+     * @param int $tpAmb 1-Production or 2-Homologation
      * @param bool $ignoreContingency
+     * @throws RuntimeException
      * @return void
      */
     protected function servico($service, $uf, $tpAmb, $ignoreContingency = false)

--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -441,7 +441,7 @@ class Tools
      * @param array $opt
      * @return array
      */
-    public function canonicalOptions($opt = [true,false,null,null])
+    public function canonicalOptions(array $opt = [true, false, null, null])
     {
         if (!empty($opt) && is_array($opt)) {
             $this->canonical = $opt;
@@ -453,27 +453,21 @@ class Tools
      * Assembles all the necessary parameters for soap communication
      * @param string $service
      * @param string $uf
-     * @param int $tpAmb
+     * @param int $tpAmb 1-Production ou 2-Testing
      * @param bool $ignoreContingency
      * @return void
      */
     protected function servico($service, $uf, $tpAmb, $ignoreContingency = false)
     {
-        $ambiente = $tpAmb == 1 ? "producao" : "homologacao";
         $webs = new Webservices($this->getXmlUrlPath());
         $sigla = $uf;
         if (!$ignoreContingency) {
             $contType = $this->contingency->type;
-            if (!empty($contType)
-                && ($contType == 'SVCRS' || $contType == 'SVCAN')
-            ) {
+            if (!empty($contType) && ($contType == 'SVCRS' || $contType == 'SVCAN')) {
                 $sigla = $contType;
             }
         }
-        $stdServ = $webs->get($sigla, $ambiente, $this->modelo);
-        if ($stdServ === false) {
-            throw new \RuntimeException("Nenhum servico encontrado para UF [$sigla], modelo [$this->modelo]");
-        }
+        $stdServ = $webs->get($sigla, $tpAmb, $this->modelo);
         if (empty($stdServ->$service->url)) {
             throw new \RuntimeException("Servico [$service] indisponivel UF [$uf] ou modelo [$this->modelo]");
         }
@@ -485,8 +479,7 @@ class Tools
         $this->urlService = $stdServ->$service->url; //recuperação da url do serviço
         $this->urlMethod = $stdServ->$service->method; //recuperação do método
         $this->urlOperation = $stdServ->$service->operation; //recuperação da operação
-        //monta namespace do serviço
-        $this->urlNamespace = sprintf("%s/wsdl/%s", $this->urlPortal, $this->urlOperation);
+        $this->urlNamespace = sprintf("%s/wsdl/%s", $this->urlPortal, $this->urlOperation); //monta namespace
         //montagem do cabeçalho da comunicação SOAP
         $this->urlHeader = Header::get($this->urlNamespace, $this->urlcUF, $this->urlVersion);
         $this->urlAction = "\"$this->urlNamespace/$this->urlMethod\"";

--- a/src/Common/Webservices.php
+++ b/src/Common/Webservices.php
@@ -3,8 +3,7 @@
 namespace NFePHP\NFe\Common;
 
 /**
- * Class to Read and preprocess WS parameters from xml storage
- * file to json encode or stdClass
+ * Reads and preprocesses WS parameters from xml storage file to json encode or stdClass
  *
  * @category  NFePHP
  * @package   NFePHP\NFe\Common\Webservices
@@ -34,15 +33,14 @@ class Webservices
     }
     
     /**
-     * Get webservices parameters for specific conditions
-     * the parameters with the authorizers are in a json file in
-     * the storage folder
+     * Gets webservices parameters for specific conditions
      * @param string $sigla
-     * @param string $ambiente "homologacao" ou "producao"
+     * @param int $amb 1-Produção ou 2-Homologação
      * @param int $modelo "55" ou "65"
-     * @return bool | \stdClass
+     * @return \stdClass
+     * @see storage/autorizadores.json
      */
-    public function get($sigla, $ambiente, $modelo)
+    public function get($sigla, $amb, $modelo)
     {
         $autfile = realpath(__DIR__ . '/../../storage/autorizadores.json');
         $autorizadores = json_decode(file_get_contents($autfile), true);
@@ -51,11 +49,12 @@ class Webservices
         }
         $auto = $autorizadores[$modelo][$sigla];
         if (empty($auto) || empty($this->std)) {
-            return false; // TODO fmertins 24/09/18: throw exception e nao retornar mais false...?
+            throw new \RuntimeException('Falhou autorizador, parece vazio');
         }
         if (empty($this->std->$auto)) {
             throw new \RuntimeException("Nao existem webservices cadastrados para [$sigla] no modelo [$modelo]");
         }
+        $ambiente = $amb == 1 ? 'producao' : 'homologacao';
         $svw = $this->std->$auto->$ambiente;
         if ($auto == 'SVRS' || $auto == 'SVAN') {
             $pad = !empty($this->std->$sigla->$ambiente) ? $this->std->$sigla->$ambiente : '';

--- a/tests/Common/WebservicesTest.php
+++ b/tests/Common/WebservicesTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fernando
+ * Date: 28/09/18
+ * Time: 18:00
+ */
+
+namespace NFePHP\NFe\Tests\Common;
+
+use NFePHP\NFe\Common\Webservices;
+
+class WebservicesTest extends \PHPUnit_Framework_TestCase
+{
+    const SEFAZ_AMB_HOMOLOG = '2';
+    const NFE_MODELO_55 = 55;
+    const AN_INVALID_BRAZILIAN_UF_ABREV = 'XY';
+    
+    /**
+     * @var string
+     */
+    protected $xml;
+    
+    protected function setUp()
+    {
+        $filepath = __DIR__ . '/../../storage/wsnfe_4.00_mod55.xml';
+        $this->xml = file_get_contents($filepath);
+    }
+    
+    public function testIcanInstantiate()
+    {
+        $this->assertInstanceOf('NFePHP\NFe\Common\Webservices', new Webservices($this->xml));
+    }
+    
+    public function testGetWebserviceValidUF()
+    {
+        $ws = new Webservices($this->xml);
+        $ret = $ws->get('RS', self::SEFAZ_AMB_HOMOLOG, self::NFE_MODELO_55);
+        $this->assertInstanceOf('\\stdClass', $ret);
+    }
+    
+    public function testRuntimeExceptionUsingAnInvalidUF()
+    {
+        $this->expectException(\RuntimeException::class);
+        $ws = new Webservices($this->xml);
+        $ws->get(self::AN_INVALID_BRAZILIAN_UF_ABREV, self::SEFAZ_AMB_HOMOLOG, self::NFE_MODELO_55);
+    }
+}


### PR DESCRIPTION
1) Webservice::get() parâmetro do ambiente agora é numérico para padronizar e simplificar.
1.2) Ocorrência de uso deste método é apenas uma, refatorado na Tools.
1.3) Removida opção de return false pois no código-cliente do método verificava por false e neste caso levantava uma Exception, então alterado para já fazer isso na própria classe, e o que também facilitou a criação do assertEquals() no teste do método.
1.4) Sendo assim a variável $ambiente por extenso foi movida para apenas o método e não mais o código-cliente que o chamava, na Tools.
2) Tools::servico(), adequações ao método get() refatorado e outras melhorias minimalistas.
3) Novo arquivo "tests/Common/WebservicesTest.php".
4) phpunit.xml.dist, nova linha comentada opção de code coverage report saída em tela (stdout do PHP).