### PR TITLE
Remove number_format de vBC em tagPIS (torna tag opcinal no CST 72)

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -4833,7 +4833,7 @@ class Make
                 $this->dom->addChild(
                     $pisItem,
                     'vBC',
-                    number_format($std->vBC, 2, '.', ''),
+                    $std->vBC,
                     ($std->vBC !== null) ? true : false,
                     "[item $std->item] Valor da Base de Cálculo do PIS"
                 );


### PR DESCRIPTION
Com a função number_format ao especificar `$std->vBC = null;` ou omitir, a classe cria a tag vBC no xml com valor '0.00'.
No PIS 72 não deve haver a tag