### PR TITLE
Adicionado chamada da função Strings::replaceLineBreak para as tags i…

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -6275,14 +6275,14 @@ class Make
         $this->dom->addChild(
             $this->infAdic,
             "infAdFisco",
-            $std->infAdFisco,
+            Strings::replaceLineBreak($std->infAdFisco),
             false,
             "Informações Adicionais de Interesse do Fisco"
         );
         $this->dom->addChild(
             $this->infAdic,
             "infCpl",
-            $std->infCpl,
+            Strings::replaceLineBreak($std->infCpl),
             false,
             "Informações Complementares de interesse do Contribuinte"
         );


### PR DESCRIPTION
Adicionado chamada da função Strings::replaceLineBreak para as tags infAdFisco e infCpl.

Adicionei na classe Strings a função replaceLineBreak. https://github.com/nfephp-org/sped-common/pull/195
Essa função vai ser utilizada no projeto da NF-e (/nfephp-org/sped-nfe) para o preenchimento das tags infAdFisco e infCpl.
Pois ao preencher as mesmas com uma quebra de linha, gera o erro :
conteudo.. is not accepted by the pattern '[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}'
Para gerar uma quebra de linha., devemos trocar a quebra de linha pelo caractere ";" (ponto e virgula).