### PR TITLE
[UPD] correção URI consulta NFCe PI

### DIFF
--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -200,6 +200,15 @@
     </producao>
   </UF>
   <UF>
+    <sigla>PI</sigla>
+    <homologacao>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://webas.sefaz.pi.gov.br/nfceweb-homologacao/consultarNFCe.jsf</NfeConsultaQR>
+    </homologacao>
+    <producao>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://webas.sefaz.pi.gov.br/nfceweb/consultarNFCe.jsf</NfeConsultaQR>
+    </producao>
+  </UF>
+  <UF>
     <sigla>PR</sigla>
     <homologacao>
        <NfeAutorizacao method="nfeAutorizacaoLote" operation="NFeAutorizacao4" version="4.00">https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeAutorizacao4</NfeAutorizacao>


### PR DESCRIPTION
A URL de consulta de NFC-e da Sefaz Piauí que é utilizado para codificar QR Code deve ser descrita como acrescido. No presente commit foi adicionado o nó com a url correta para a emissão de NFCE no estado do Piauí, de acordo com solução indicada por Leandro Alfredo em: https://groups.google.com/forum/#!msg/nfephp/8J5FpoWgm_g/gs_ttACUCgAJ