### PR TITLE
[UPD] Erro ao protocolar eventos NFC-e/MS

### DIFF
--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -189,7 +189,7 @@
        <NfeInutilizacao  method="nfeInutilizacaoNF" operation="NFeInutilizacao4" version="4.00">https://nfce.sefaz.ms.gov.br/ws/NFeInutilizacao4</NfeInutilizacao>
        <NfeConsultaProtocolo method="nfeConsultaNF" operation="NFeConsultaProtocolo4" version="4.00">https://nfce.sefaz.ms.gov.br/ws/NFeConsultaProtocolo4</NfeConsultaProtocolo>
        <NfeStatusServico method="nfeStatusServicoNF" operation="NFeStatusServico4" version="4.00">https://nfce.sefaz.ms.gov.br/ws/NFeStatusServico4</NfeStatusServico>
-       <RecepcaoEvento  method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento" version="1.00">https://nfce.sefaz.ms.gov.br/ws/NFeRecepcaoEvento4</RecepcaoEvento>
+       <RecepcaoEvento  method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento4" version="1.00">https://nfce.sefaz.ms.gov.br/ws/NFeRecepcaoEvento4</RecepcaoEvento>
        <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.dfe.ms.gov.br/nfce/qrcode</NfeConsultaQR>
     </producao>
   </UF>


### PR DESCRIPTION
A operação para o método `nfeRecepcaoEvento` da SEFAZ/MS no arquivo `wsnfe_4.00_mod65.xml` está incorreta.

> Este PR resolve o _ERRO **500**_ ao tentar protocolar uma evento nesta SEFAZ.