### PR TITLE
Erros DOM parsers

### DIFF
--- a/src/Factories/Parser.php
+++ b/src/Factories/Parser.php
@@ -141,6 +141,15 @@ class Parser
     }
 
     /**
+     * Retorna erros na criacao do DOM
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->make->erros;
+    }
+
+    /**
      * Converte txt array to xml
      * @param array $nota
      * @return void


### PR DESCRIPTION
metodo para pegar os erros do DOM, hoje o toXML retorna null e nao tem como recuperar esses erros.