### PR TITLE
pICMSInter Casas decimais

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -16,6 +16,7 @@ namespace NFePHP\NFe;
 
 use NFePHP\NFe\Common\ValidTXT;
 use NFePHP\NFe\Exception\DocumentsException;
+use NFePHP\NFe\Exception\ParserException;
 use NFePHP\NFe\Factories\Parser;
 
 class Convert
@@ -77,6 +78,9 @@ class Convert
             $version = $this->layouts[$i];
             $parser = new Parser($version, $this->baselayout);
             $this->xmls[] = $parser->toXml($nota);
+            if ($errors = $parser->getErrors()) {
+                throw new ParserException(implode(', ', $errors));
+            }
             $i++;
         }
         return $this->xmls;

--- a/src/Exception/ParserException.php
+++ b/src/Exception/ParserException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NFePHP\NFe\Exception;
+
+/**
+ * @category   NFePHP
+ * @package    NFePHP\NFe\Exception
+ * @copyright  Copyright (c) 2008-2019
+ * @license    http://www.gnu.org/licenses/lesser.html LGPL v3
+ * @author     Roberto L. Machado <linux.rlm at gmail dot com>
+ * @link       http://github.com/nfephp-org/sped-common for the canonical source repository
+ */
+
+class ParserException extends \InvalidArgumentException implements
+    ExceptionInterface
+{
+}

--- a/src/Make.php
+++ b/src/Make.php
@@ -4666,7 +4666,7 @@ class Make
         $this->dom->addChild(
             $icmsUFDest,
             "pICMSInter",
-            $this->conditionalNumberFormatting($std->pICMSInter, 4),
+            $this->conditionalNumberFormatting($std->pICMSInter, 2),
             true,
             "[item $std->item] Alíquota interestadual das UF envolvidas"
         );


### PR DESCRIPTION
Esse XML não é válido. Elemento 'pICMSInter': [Erro 'Conteúdo'] O valor '4.0000' não é um dos seguintes possiveis {'4.00', '7.00', '12.00'}.

Elemento 'pICMSInter': '4.0000' não é um valor válido.

![image](https://user-images.githubusercontent.com/2566340/59683707-0cb4f180-91af-11e9-8394-d5f74a19aab1.png)
