### PR TITLE
Ajustando descrição do primeiro item da NFCe em homologação

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1721,7 +1721,7 @@ class Make
             true
         );
         $xProd = $std->xProd;
-        if ($this->tpAmb == '2' && $this->mod == '65') {
+	if ($this->tpAmb == '2' && $this->mod == '65' && (isset($std->item) && $std->item === 1)) {
             $xProd = 'NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
         }
         $this->dom->addChild(

--- a/src/Make.php
+++ b/src/Make.php
@@ -1721,9 +1721,9 @@ class Make
             true
         );
         $xProd = $std->xProd;
-	if ($this->tpAmb == '2' && $this->mod == '65' && (isset($std->item) && $std->item === 1)) {
-            $xProd = 'NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
-        }
+	    if ($this->tpAmb == '2' && $this->mod == '65' && (isset($std->item) && $std->item === 1)) {
+	        $xProd = 'NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
+	    }
         $this->dom->addChild(
             $prod,
             "xProd",


### PR DESCRIPTION
De acordo com a NT2015 002_V1_30 Regra I04-10. Apenas o primeiro item deve ser enviado com a descrição "NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL".