### PR TITLE
add cstat de uso denegado

### DIFF
--- a/src/Complements.php
+++ b/src/Complements.php
@@ -259,7 +259,8 @@ class Complements
                     //205 NFe Denegada
                     //301 Uso denegado por irregularidade fiscal do emitente
                     //302 Uso denegado por irregularidade fiscal do destinatário
-                    $cstatpermit = ['100', '150', '110', '205', '301','302'];
+                    //303 Uso Denegado Destinatario nao habilitado a operar na UF
+                    $cstatpermit = ['100', '150', '110', '205', '301', '302', '303'];
                     if (!in_array($cStat, $cstatpermit)) {
                         throw DocumentsException::wrongDocument(4, "[$cStat] $xMotivo");
                     }


### PR DESCRIPTION

- Adicionado  cstat  "303".

303 - Uso Denegado: Destinatário não habilitado a operar na UF:
Esta rejeição retorna nos casos em que a Inscrição Estadual do destinatário não corresponde a UF que foi informada na nota. 