### PR TITLE
Atualização dev dep PHPUnit 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ clearTags
 build
 composer.lock
 config.json
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 7.4snapshot
   - nightly
 
-dist: precise
+dist: xenial
 sudo: false
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.2
   - 7.3
   - 7.4snapshot
+  - nightly
 
 dist: precise
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4snapshot
 
 dist: precise
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ php:
 dist: xenial
 sudo: false
 
+matrix:
+  allow_failures:
+    - php: 7.4snapshot
+    - php: nightly
+
 before_script:
   - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^8.3",
         "scrutinizer/ocular": "^1.3",
-        "sebastian/phpcpd": "^3.0",
+        "sebastian/phpcpd": "^4.1",
         "phpstan/phpstan": "^0.9.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
-        "phpunit/phpunit": "^8.3",
+        "phpunit/phpunit": "^7.5",
         "scrutinizer/ocular": "^1.3",
         "sebastian/phpcpd": "^4.1",
         "phpstan/phpstan": "^0.9.2"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,10 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         failOnRisky="true"
+         failOnWarning="true">
     <testsuites>
         <testsuite name="sped-nfe Test Suite">
             <directory>tests</directory>
@@ -19,12 +22,12 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <logging>
+    <!--<logging>-->
         <!--<log type="tap" target="build/report.tap"/>-->
         <!--<log type="junit" target="build/report.junit.xml"/>-->
         <!--<log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>-->
         <!--<log type="coverage-text" target="build/coverage.txt"/>-->
         <!--<log type="coverage-text" target="php://stdout"/>-->
         <!--<log type="coverage-clover" target="build/logs/clover.xml"/>-->
-    </logging>
+    <!--</logging>-->
 </phpunit>

--- a/tests/Common/ConfigTest.php
+++ b/tests/Common/ConfigTest.php
@@ -13,7 +13,7 @@ class ConfigTest extends NFeTestCase
         $b = is_object($resp);
         $this->assertTrue($b);
     }
-    
+
     public function testValidadeWithoutSomeOptionalData()
     {
         $config = [
@@ -38,13 +38,11 @@ class ConfigTest extends NFeTestCase
         $b = is_object($resp);
         $this->assertTrue($b);
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testValidadeFailWithArray()
     {
-         $config = [
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
+        $config = [
             "atualizacao" => "2017-02-20 09:11:21",
             "tpAmb" => 2,
             "razaosocial" => "SUA RAZAO SOCIAL LTDA",
@@ -61,23 +59,19 @@ class ConfigTest extends NFeTestCase
                 "proxyUser" => "",
                 "proxyPass" => ""
             ]
-         ];
-         $resp = Config::validate($config);
+        ];
+        $resp = Config::validate($config);
     }
 
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
     public function testValidadeFailWithoutJsonString()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $resp = Config::validate('');
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testValidadeFailWithoutTpAmb()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $config = [
             "atualizacao" => "2017-02-20 09:11:21",
             //"tpAmb" => 2,
@@ -98,12 +92,10 @@ class ConfigTest extends NFeTestCase
         ];
         $resp = Config::validate(json_encode($config));
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testValidadeFailWithoutRazao()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $config = [
             //"atualizacao" => "2017-02-20 09:11:21",
             "tpAmb" => 2,
@@ -124,12 +116,10 @@ class ConfigTest extends NFeTestCase
         ];
         $resp = Config::validate(json_encode($config));
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testValidadeFailWithoutUF()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $config = [
             //"atualizacao" => "2017-02-20 09:11:21",
             "tpAmb" => 2,
@@ -150,12 +140,10 @@ class ConfigTest extends NFeTestCase
         ];
         $resp = Config::validate(json_encode($config));
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testValidadeFailWithoutCNPJ()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $config = [
             //"atualizacao" => "2017-02-20 09:11:21",
             "tpAmb" => 2,
@@ -177,11 +165,9 @@ class ConfigTest extends NFeTestCase
         $resp = Config::validate(json_encode($config));
     }
 
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
     public function testValidadeFailWithoutSchemes()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $config = [
             //"atualizacao" => "2017-02-20 09:11:21",
             "tpAmb" => 2,
@@ -202,12 +188,10 @@ class ConfigTest extends NFeTestCase
         ];
         $resp = Config::validate(json_encode($config));
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testValidadeFailWithoutVersao()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $config = [
             //"atualizacao" => "2017-02-20 09:11:21",
             "tpAmb" => 2,
@@ -228,7 +212,7 @@ class ConfigTest extends NFeTestCase
         ];
         $resp = Config::validate(json_encode($config));
     }
-    
+
     public function testValidadeWithCPF()
     {
         $config = [

--- a/tests/Common/StandardizeTest.php
+++ b/tests/Common/StandardizeTest.php
@@ -14,47 +14,39 @@ class StandardizeTest extends NFeTestCase
         $resp = $st->whichIs($xml);
         $this->assertEquals('NFe', $resp);
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testWhichIsFailNotXMLSting()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $st = new Standardize();
         $resp = $st->whichIs('jslsj ks slk lk');
         $resp = $st->whichIs($xml);
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testWhichIsFailNotXMLNumber()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $st = new Standardize();
         $resp = $st->whichIs(100);
         $resp = $st->whichIs($xml);
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testWhichIsFailNotXMLSpace()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $st = new Standardize();
         $resp = $st->whichIs('  ');
         $resp = $st->whichIs($xml);
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testWhichIsFailNotBelongToNFe()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $st = new Standardize();
         $xml = file_get_contents($this->fixturesPath. 'xml/cte.xml');
         $st->whichIs($xml);
     }
-    
+
     public function testToNode()
     {
         $xml = file_get_contents($this->fixturesPath. 'xml/2017nfe_antiga_v310.xml');
@@ -71,7 +63,7 @@ class StandardizeTest extends NFeTestCase
         $actualElement = $actualDom->documentElement;
         $this->assertEqualXMLStructure($expectedElement, $actualElement);
     }
-    
+
     public function testToJson()
     {
         $xml = file_get_contents($this->fixturesPath. 'xml/2017nfe_antiga_v310.xml');
@@ -79,7 +71,7 @@ class StandardizeTest extends NFeTestCase
         $expected = file_get_contents($this->fixturesPath. 'txt/2017nova-nfe.json');
         $this->assertEquals($expected, $st->toJson());
     }
-    
+
     public function testToArray()
     {
         $xml = file_get_contents($this->fixturesPath. 'xml/2017nfe_antiga_v310.xml');
@@ -87,7 +79,7 @@ class StandardizeTest extends NFeTestCase
         $expected = json_decode(file_get_contents($this->fixturesPath. 'txt/2017nova-nfe.json'), true);
         $this->assertEquals($expected, $st->toArray());
     }
-    
+
     public function testToStd()
     {
         $xml = file_get_contents($this->fixturesPath. 'xml/2017nfe_antiga_v310.xml');

--- a/tests/Common/ValidTXTTest.php
+++ b/tests/Common/ValidTXTTest.php
@@ -18,16 +18,13 @@ class ValidTXTTest extends NFeTestCase
         );
         $txt = file_get_contents($this->fixturesPath . 'txt/nfe_errado.txt');
         $actual = ValidTXT::isValid($txt);
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             $expected,
             $actual,
-            "\$canonicalize = true",
-            $delta = 0.0,
-            $maxDepth = 1,
-            $canonicalize = true
+            "\$canonicalize = true"
         );
     }
-    
+
     public function testIsValidSebrae()
     {
         $expected = [];
@@ -45,19 +42,16 @@ class ValidTXTTest extends NFeTestCase
         );
          */
     }
-    
+
     public function testIsValidLocal()
     {
         $expected = [];
         $txt = file_get_contents($this->fixturesPath . 'txt/nfe_4.00_local_01.txt');
         $actual = ValidTXT::isValid($txt, ValidTXT::LOCAL);
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             $expected,
             $actual,
-            "\$canonicalize = true",
-            $delta = 0.0,
-            $maxDepth = 1,
-            $canonicalize = true
+            "\$canonicalize = true"
         );
     }
 }

--- a/tests/Common/ValidTXTTest.php
+++ b/tests/Common/ValidTXTTest.php
@@ -8,7 +8,7 @@ use NFePHP\NFe\Tests\NFeTestCase;
 class ValidTXTTest extends NFeTestCase
 {
     /**
-     * @covers ValidTXT::<protected>
+     * @covers \NFePHP\NFe\Common\ValidTXT::isValid
      */
     public function testIsValidFail()
     {

--- a/tests/Common/WebservicesTest.php
+++ b/tests/Common/WebservicesTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Created by PhpStorm.
  * User: fernando
@@ -9,36 +10,37 @@
 namespace NFePHP\NFe\Tests\Common;
 
 use NFePHP\NFe\Common\Webservices;
+use PHPUnit\Framework\TestCase;
 
-class WebservicesTest extends \PHPUnit_Framework_TestCase
+class WebservicesTest extends TestCase
 {
     const SEFAZ_AMB_HOMOLOG = '2';
     const NFE_MODELO_55 = 55;
     const AN_INVALID_BRAZILIAN_UF_ABREV = 'XY';
-    
+
     /**
      * @var string
      */
     protected $xml;
-    
-    protected function setUp()
+
+    protected function setUp(): void
     {
         $filepath = __DIR__ . '/../../storage/wsnfe_4.00_mod55.xml';
         $this->xml = file_get_contents($filepath);
     }
-    
+
     public function testIcanInstantiate()
     {
         $this->assertInstanceOf('NFePHP\NFe\Common\Webservices', new Webservices($this->xml));
     }
-    
+
     public function testGetWebserviceValidUF()
     {
         $ws = new Webservices($this->xml);
         $ret = $ws->get('RS', self::SEFAZ_AMB_HOMOLOG, self::NFE_MODELO_55);
         $this->assertInstanceOf('\\stdClass', $ret);
     }
-    
+
     public function testRuntimeExceptionUsingAnInvalidUF()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Factories/QRCodeTest.php
+++ b/tests/Factories/QRCodeTest.php
@@ -24,14 +24,14 @@ class QRCodeTest extends NFeTestCase
         $sigla = '';
         $versao = '200';
         $urlqr = 'https://www.homologacao.nfce.fazenda.sp.gov.br/NFCeConsultaPublica/Paginas/ConsultaQRCode.aspx';
-        
+
         $expected = file_get_contents($this->fixturesPath.'xml/nfce_com_qrcode.xml');
         $expectedDom = new \DOMDocument('1.0', 'UTF-8');
         $expectedDom->formatOutput = false;
         $expectedDom->preserveWhiteSpace = false;
         $expectedDom->load($this->fixturesPath . 'xml/nfce_com_qrcode.xml');
         $expectedElement = $expectedDom->documentElement;
-        
+
         $response = QRCode::putQRTag($dom, $token, $idToken, $versao, $urlqr);
         $actualDom = new \DOMDocument('1.0', 'UTF-8');
         $actualDom->formatOutput = false;
@@ -40,12 +40,10 @@ class QRCodeTest extends NFeTestCase
         $actualElement = $actualDom->documentElement;
         $this->assertEqualXMLStructure($expectedElement, $actualElement);
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testPutQRTagFailWithoutCSC()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -57,12 +55,10 @@ class QRCodeTest extends NFeTestCase
         $urlqr = 'https://www.homologacao.nfce.fazenda.sp.gov.br/NFCeConsultaPublica/Paginas/ConsultaQRCode.aspx';
         $response = QRCode::putQRTag($dom, $token, $idToken, $versao, $urlqr);
     }
-    
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
+
     public function testPutQRTagFailWithoutCSCid()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -75,11 +71,9 @@ class QRCodeTest extends NFeTestCase
         $response = QRCode::putQRTag($dom, $token, $idToken, $versao, $urlqr);
     }
 
-    /**
-     * @expectedException NFePHP\NFe\Exception\DocumentsException
-     */
     public function testPutQRTagFailWithoutURL()
     {
+        $this->expectException(\NFePHP\NFe\Exception\DocumentsException::class);
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;

--- a/tests/Factories/QRCodeTest.php
+++ b/tests/Factories/QRCodeTest.php
@@ -4,13 +4,12 @@ namespace NFePHP\NFe\Tests\Factories;
 
 use NFePHP\NFe\Factories\QRCode;
 use NFePHP\NFe\Tests\NFeTestCase;
-use NFePHP\NFe\Exception\DocumentsException;
 
 class QRCodeTest extends NFeTestCase
 {
     /**
-     * @covers QRCode::get
-     * @covers QRCode::str2Hex
+     * @covers \NFePHP\NFe\Factories\QRCode::get200
+     * @covers \NFePHP\NFe\Factories\QRCode::str2Hex
      */
     public function testPutQRTag()
     {

--- a/tests/MakeTest.php
+++ b/tests/MakeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace NFePHP\NFe\Tests;
 
@@ -138,24 +139,24 @@ class MakeTest extends TestCase
         $ide = $this->make->tagide($std);
 
         $this->assertEmpty($ide->getElementsByTagName('cUF')->item(0)->nodeValue);
-        $this->assertContains('cUF', $this->make->dom->errors[0]);
+        $this->assertStringContainsString('cUF', $this->make->dom->errors[0]);
         $this->assertEquals('78888888', $ide->getElementsByTagName('cNF')->item(0)->nodeValue);
         $this->assertEmpty($ide->getElementsByTagName('natOp')->item(0)->nodeValue);
-        $this->assertContains('natOp', $this->make->dom->errors[1]);
-        $this->assertContains('mod', $this->make->dom->errors[2]);
-        $this->assertContains('serie', $this->make->dom->errors[3]);
-        $this->assertContains('nNF', $this->make->dom->errors[4]);
-        $this->assertContains('dhEmi', $this->make->dom->errors[5]);
-        $this->assertContains('tpNF', $this->make->dom->errors[6]);
-        $this->assertContains('idDest', $this->make->dom->errors[7]);
-        $this->assertContains('cMunFG', $this->make->dom->errors[8]);
+        $this->assertStringContainsString('natOp', $this->make->dom->errors[1]);
+        $this->assertStringContainsString('mod', $this->make->dom->errors[2]);
+        $this->assertStringContainsString('serie', $this->make->dom->errors[3]);
+        $this->assertStringContainsString('nNF', $this->make->dom->errors[4]);
+        $this->assertStringContainsString('dhEmi', $this->make->dom->errors[5]);
+        $this->assertStringContainsString('tpNF', $this->make->dom->errors[6]);
+        $this->assertStringContainsString('idDest', $this->make->dom->errors[7]);
+        $this->assertStringContainsString('cMunFG', $this->make->dom->errors[8]);
         $this->assertEquals('0', $ide->getElementsByTagName('cDV')->item(0)->nodeValue);
-        $this->assertContains('tpAmb', $this->make->dom->errors[9]);
-        $this->assertContains('finNFe', $this->make->dom->errors[10]);
-        $this->assertContains('indFinal', $this->make->dom->errors[11]);
-        $this->assertContains('indPres', $this->make->dom->errors[12]);
-        $this->assertContains('procEmi', $this->make->dom->errors[13]);
-        $this->assertContains('verProc', $this->make->dom->errors[14]);
+        $this->assertStringContainsString('tpAmb', $this->make->dom->errors[9]);
+        $this->assertStringContainsString('finNFe', $this->make->dom->errors[10]);
+        $this->assertStringContainsString('indFinal', $this->make->dom->errors[11]);
+        $this->assertStringContainsString('indPres', $this->make->dom->errors[12]);
+        $this->assertStringContainsString('procEmi', $this->make->dom->errors[13]);
+        $this->assertStringContainsString('verProc', $this->make->dom->errors[14]);
     }
 
     public function testTagideVersaoQuantroPontoZeroModeloCinquentaECincoEmContigencia()
@@ -230,7 +231,7 @@ class MakeTest extends TestCase
         $this->assertEmpty($ide->getElementsByTagName('xJust')->item(0));
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->make = new Make();
     }

--- a/tests/ToolsTest.php
+++ b/tests/ToolsTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace NFePHP\NFe\Tests;
 
@@ -13,7 +14,7 @@ class ToolsTest extends NFeTestCase
      */
     protected $tools;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tools = new Tools(
             $this->configJson,


### PR DESCRIPTION
* Incrementando versão no composer.json
* Refatorando métodos e meta docs depreciados: `@expectedException`, `assertContains`
* Refatorando métodos com argumentos depreciados: `assertEquals`
* Travis com versão PHP 7.3, 7.4 e 8.0.0 :rocket: :rocket:
* Uso de strict types para sobrescrever corretamente o método `setUp` do PHPUnit