### PR TITLE
Tag tagICMSSN formatação campo vBCFCPSTRet

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -4421,7 +4421,7 @@ class Make
                 $this->dom->addChild(
                     $icmsSN,
                     'vBCFCPSTRet',
-                    $this->conditionalNumberFormatting($std->vBCFCPSTRet, 4),
+                    $this->conditionalNumberFormatting($std->vBCFCPSTRet, 2),
                     isset($std->vBCFCPSTRet) ? true : false,
                     "[item $std->item] Valor da Base de Cálculo do FCP "
                     . "retido anteriormente por Substituição Tributária"


### PR DESCRIPTION
Olá, estava tentando gerar uma NF-e com a tag "tagICMSSN", porém o campo vBCFCPSTRet está setando pra formatar com 4 casas decimais, gerando o seguinte erro ao validar o XML.

This XML is not valid. Element '{http://www.portalfiscal.inf.br/nfe}vBCFCPSTRet': [facet 'pattern'] The value '150.5000' is not accepted by the pattern '0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?'. Element '{http://www.portalfiscal.inf.br/nfe}vBCFCPSTRet': '150.5000' is not a valid value of the atomic type '{http://www.portalfiscal.inf.br/nfe}TDec_1302'.

Após colocar as duas casas decimais, o xml foi validado corretamente.

Grato!