### PR TITLE
Update wsnfe_4.00_mod65.xml

### DIFF
--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -53,7 +53,7 @@
   <UF>
     <sigla>BA</sigla>
     <homologacao>
-       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://nfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx</NfeConsultaQR>
+       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://hnfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx</NfeConsultaQR>
     </homologacao>
     <producao>
        <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://nfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx</NfeConsultaQR>


### PR DESCRIPTION
Corrigindo a URL de consulta do QR-CODE de homologação do estado da Bahia(BA), pois estava acusando a rejeição "395 - Endereço do site da UF da Consulta via QR-Code diverge do previsto".

A correção foi baseada na documentação do estado da BA, disponível no link: http://nfe.sefaz.ba.gov.br/servicos/nfce/documentos/configuracao_programa_emissor_REV_3.pdf