### PR TITLE
Erro na identificação de certificado de CPF

### DIFF
--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -212,6 +212,7 @@ class Tools
     public function getTypeOfPersonFromCertificate()
     {
         $cnpj = $this->certificate->getCnpj();
+        $cpf = $this->certificate->getCpf();
         $type = 'J';
         if (substr($cnpj, 0, 1) === 'N') {
             //não é CNPJ, então verificar se é CPF
@@ -222,6 +223,10 @@ class Tools
                 //não foi localizado nem CNPJ e nem CPF esse certificado não é usável
                 //throw new RuntimeException('Faltam elementos CNPJ/CPF no certificado digital.');
                 $type = '';
+            }
+        }else{//caso em que cnpj é nulo e cpf está presente
+            if(empty($cnpj) and !empty($cpf)){
+                $type = 'F';
             }
         }
         return $type;


### PR DESCRIPTION
Meu certificado é CPF de produtor rural
e de todas as formas que tentei ele não reconhecia isso
percebi que o padrão era que a variavel $cnpj ficava em branco
mas a variavel $cpf vinha com valor correto
essa alteração nessa função fez com que a tentativa de cancelamento que antes estava dando erro de schemas devido a tag ser CNPJ
desse sucesso agora que está identificando a tag como CPF