### PR TITLE
[UPD] ISSUE #726 Make::class totalização vBC e vICMS

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -3279,9 +3279,6 @@ class Make
                 );
                 break;
             case '51':
-                $this->stdTot->vBC += (float) !empty($std->vBC) ? $std->vBC : 0;
-                $this->stdTot->vICMS += (float) !empty($std->vICMS) ? $std->vICMS : 0;
-
                 $icms = $this->dom->createElement("ICMS51");
                 $this->dom->addChild(
                     $icms,


### PR DESCRIPTION
- Não incluir no calculo da totalização vBC e vICMS dos itens com CST 51 (NT 2010_010 pagina 16).