### PR TITLE
Fix Travis CI para versão PHP: 7.4snapshot

### DIFF
--- a/src/Factories/QRCode.php
+++ b/src/Factories/QRCode.php
@@ -177,7 +177,7 @@ class QRCode
         $iCount = 0;
         $tot = strlen($str);
         do {
-            $hex .= sprintf("%02x", ord($str{$iCount}));
+            $hex .= sprintf("%02x", ord($str[$iCount]));
             $iCount++;
         } while ($iCount < $tot);
         return $hex;


### PR DESCRIPTION
Array and string offset access syntax with curly braces is deprecated