### PR TITLE
Pegando a Exception atraves do try/catch

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -77,9 +77,14 @@ class Convert
         foreach ($this->notas as $nota) {
             $version = $this->layouts[$i];
             $parser = new Parser($version, $this->baselayout);
-            $this->xmls[] = $parser->toXml($nota);
-            if ($errors = $parser->getErrors()) {
-                throw new ParserException(implode(', ', $errors));
+            try {
+                $this->xmls[] = $parser->toXml($nota);
+            } catch (\Exception $e) {
+                if ($errors = $parser->getErrors()) {
+                    throw new ParserException(implode(', ', $errors));
+                } else {
+                    throw new RuntimeException($e->getMessage());
+                }
             }
             $i++;
         }


### PR DESCRIPTION
Boa tarde.
Hoje eu tive um erro de NCM e o retorno do sistema era somente a mensagem: 'Existem erros nas tags. Obtenha os erros com getErrors().'
Debugando o programa eu notei que a classe Parse e Make contem a função getErrors(), mas as classe Convert não, com isso os erros não são apresentados, pois o retorno 
da excessão era antes da linha que recuperava o erro. 

Segue abaixo um trecho do meu codigo e o TXT com erro do NCM, apos a alteração eu consegui pegar os erros do txt.
=====================================================================================================
Trecho do codigo resumido  
=====================================================================================================
fileRead = file_get_contents($fileTXT);
try {
	$objParser = new Convert($fileRead);
        $xml = $objParser->toXml();
} catch (\Exception $e) {
	Log::critical('ERRO - processamento do arquivo (' . $fileName . '). Motivo: ' . $e->getMessage());	
}


=====================================================================================================
ARQUIVO TXT processado
=====================================================================================================
NOTAFISCAL|1|
A|4.00|||
B|53|13134751|COMPRAS PARA COMERCIALIZACO|55|1|565001|2020-01-22T14:21:15-03:00|2020-01-22T14:21:15-03:00|0|2|5300108|1|1|7|1|1|1|1|0|0.0.1|||
C|COMERCIAL DE FRUTAS MENDES IMPORTACAO E EXPORTACAO LTDA|MENDES|0732025400285||||3|
C02|52853025000301|
C05|SIA SUL TR.10 LT. 5 PAV B 7/1 BXs 7/|12||SIA/SUL|5300108|BRASILIA|DF|71208900|1058|BRASIL|6133617474|
E|LUCAS ROCHA SOUZA|2|||||
E03|82682755534|
E05|5 AR LEONEL RIBEIRO|00||LEONEL|2911204|GANDU|BA|00000000|1058|BRASIL||
H|1||
I|04.0024.0010|SEM GTIN|BANANA TERRA 20 KG||||2102|CX|65.0000|63.00000000|4095.00|SEM GTIN|CX|65.0000|63.00000000|||||1||||
M||
N|
N06|0|40|||
O||||999|
O08|53|
O10|0.00|0.00|
Q|
Q02|73|0.00|0.00|0.00|
S|
S05|73|0.00|
S07|0.00|0.00|
X|9|
Y||
Y02|000565001|4095.00|0.00|4095.00|
Y07|001|2020-02-06|4095.00|
YA|1|99|4095.00|||||
W|
W02|0.00|0.00|0.00|0.00|0.00|0.00|0.00|0.00|4095.00||||0.00|0.00|0.00|0.00|0.00|0.00|4095.00|||||
Z|| IDC-PROCON-DF-SCS Venancio 2000 Bl.B-60 sl. 240 Cep 70.333-900 - Fone 61 3212-1500 NF de Origem  /265002020 FUNRURAL 61,42|
ZD|52853025000301|Pablo|nfe@email.com|6133617474|||