### PR TITLE
Alterando Expressão Regular do campo cBenef

### DIFF
--- a/schemes/PL_009_V4/leiauteNFe_v4.00.xsd
+++ b/schemes/PL_009_V4/leiauteNFe_v4.00.xsd
@@ -877,7 +877,7 @@ Formato ”CFOP9999”.</xs:documentation>
 													<xs:simpleType>
 														<xs:restriction base="xs:string">
 															<xs:whiteSpace value="preserve"/>
-															<xs:pattern value="([!-ÿ]{8}|[!-ÿ]{10})?"/>
+															<xs:pattern value="([!-ÿ]{8}|[!-ÿ]{10}|SEM CBENEF)?"/>
 														</xs:restriction>
 													</xs:simpleType>
 												</xs:element>


### PR DESCRIPTION
De acordo com a nota técnica 2019.001 - v.1.40 e esquemas XML NF-e/NFC-e - Pacote de Liberação No. 9 (Novo leiaute da NF-e, NT 2019.001 v.1.20a) o campo cBenef pode assumiar valor SEM CBENEF.
Inclusive aqui no RS está funcionando em ambiente de homologação.