### PR TITLE
Correcao consulta cadastro MT

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -275,6 +275,9 @@ class Tools extends ToolsCommon
             . "$filter"
             . "</infCons>"
             . "</ConsCad>";
+        if (strtoupper($uf) == 'MT') {
+            $request = "<nfeDadosMsg>$request</nfeDadosMsg>" ;
+        }    
         $this->isValid($this->urlVersion, $request, 'consCad');
         $this->lastRequest = $request;
         $parameters = ['nfeDadosMsg' => $request];


### PR DESCRIPTION
Apos varios testes, consegui resolver o problema da consulta do estado do MT. Incluindo mais uma tag nfeDadosMsg no body da consulta.