### PR TITLE
Ajuste Convert.php - RuntimeException

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -17,6 +17,7 @@ namespace NFePHP\NFe;
 use NFePHP\NFe\Common\ValidTXT;
 use NFePHP\NFe\Exception\DocumentsException;
 use NFePHP\NFe\Exception\ParserException;
+use NFePHP\NFe\Exception\RuntimeException;
 use NFePHP\NFe\Factories\Parser;
 
 class Convert


### PR DESCRIPTION
Ficou faltando no início do arquivo incluir o comando `use NFePHP\NFe\Exception\RuntimeException;` que está sendo utilizado na linha 86 (agora linha 87).