### PR TITLE
Adicionar na classe Make.php a mensagem de erro de montagem do xml

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -452,7 +452,8 @@ class Make
         $this->checkNFeKey($this->dom);
         $this->xml = $this->dom->saveXML();
         if (count($this->errors) > 0) {
-            throw new RuntimeException('Existem erros nas tags. Obtenha os erros com getErrors().');
+            $msg = implode(', ', array_merge($this->errors, array('Existem erros nas tags. Obtenha os erros com getErrors().')));
+            throw new RuntimeException($msg);
         }
         return $this->xml;
     }


### PR DESCRIPTION
Na linha 455 foi adicionada um trecho para concatenar a mensagem de erro de montagem do xml à mensagem da Exception.