### PR TITLE
Adicionar na classe Make.php a mensagem de erro de montagem do xml.

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -452,7 +452,10 @@ class Make
         $this->checkNFeKey($this->dom);
         $this->xml = $this->dom->saveXML();
         if (count($this->errors) > 0) {
-            throw new RuntimeException('Existem erros nas tags. Obtenha os erros com getErrors().');
+            $domErrors = $this->errors;
+            $msgDefault = array('Existem erros nas tags. Obtenha os erros com getErrors().');
+            $msg = implode(', ', array_merge($domErrors, $msgDefault));
+            throw new RuntimeException($msg);
         }
         return $this->xml;
     }


### PR DESCRIPTION
Na linha 455 foi adicionada um trecho para concatenar a mensagem de erro de montagem do xml à mensagem da Exception.