### PR TITLE
remoção da constante SOAP_1_2

### DIFF
--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -520,7 +520,7 @@ class Tools
             $this->urlService,
             $this->urlMethod,
             $this->urlAction,
-            SOAP_1_2,
+            2,
             $parameters,
             $this->soapnamespaces,
             $request,


### PR DESCRIPTION
o novo php 8.0 não está aceitando essa constante SOAP_1_2
de acordo com essa documentação essa constante é = 2
https://www.php.net/manual/pt_BR/soap.constants.php

então com essa pequena alteração o php 8 passa a emitir nfe's normalmente.