### PR TITLE
Ajusta URLs da NFC-e em SC

### DIFF
--- a/storage/uri_consulta_nfce.json
+++ b/storage/uri_consulta_nfce.json
@@ -22,7 +22,7 @@
         "RO": "www.sefin.ro.gov.br\/nfce\/consulta",
         "RR": "www.sefaz.rr.gov.br\/nfce\/consulta",
         "RS": "www.sefaz.rs.gov.br\/nfce\/consulta",
-        "SC": "https:\/hom.sat.sef.sc.gov.br\/nfce\/consulta",
+        "SC": "https:\/\/hom.sat.sef.sc.gov.br\/nfce\/consulta",
         "SE": "http:\/\/www.nfce.se.gov.br\/nfce\/consulta",
         "SP": "https:\/\/www.nfce.fazenda.sp.gov.br\/NFCeConsultaPublica",
         "TO": "www.sefaz.to.gov.br\/nfce\/consulta",
@@ -53,7 +53,7 @@
         "RR": "www.sefaz.rr.gov.br\/nfce\/consulta",
         "RS": "www.sefaz.rs.gov.br\/nfce\/consulta",
         "SE": "http:\/\/www.hom.nfe.se.gov.br\/nfce\/consulta",
-        "SC": "https:\/hom.sat.sef.sc.gov.br\/nfce\/consulta",
+        "SC": "https:\/\/hom.sat.sef.sc.gov.br\/nfce\/consulta",
         "SP": "https:\/\/www.homologacao.nfce.fazenda.sp.gov.br\/NFCeConsultaPublica",
         "TO": "www.sefaz.to.gov.br\/nfce\/consulta"
     }

--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -310,10 +310,10 @@
   <UF>
     <sigla>SC</sigla>
     <homologacao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://hom.sat.sef.sc.gov.br/nfce/consulta</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://hom.sat.sef.sc.gov.br/nfce/consulta</NfeConsultaQR>
     </homologacao>
     <producao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://sat.sef.sc.gov.br/nfce/consulta</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://sat.sef.sc.gov.br/nfce/consulta</NfeConsultaQR>
     </producao>
   </UF>
   <UF>


### PR DESCRIPTION
No `storage/uri_consulta_nfce.json` estava com erro e no `storage/wsnfe_4.00_mod65.xml` foi adicionado HTTPS