### PR TITLE
Delete eventoCancEntregaNFe_v1.00.xsd

### DIFF
--- a/schemes/PL_009_V4/eventoCancEntregaNFe_v1.00.xsd
+++ b/schemes/PL_009_V4/eventoCancEntregaNFe_v1.00.xsd
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:include schemaLocation="leiauteEventoCancEntregaNFe_v1.00.xsd"/>
-	<xs:element name="evento" type="TEvento">
-		<xs:annotation>
-			<xs:documentation>Schema XML de validação do evento de Cancelamento do Comprovante de Entrega da NFe</xs:documentation>
-		</xs:annotation>
-	</xs:element>
-</xs:schema>


### PR DESCRIPTION
Arquivo duplicado, gerando erro em sistemas case insensitive

Mensagem:
 [ErrorException]                                                                                  
  ZipArchive::extractTo(/var/www/pdvx/vendor/composer/8cee84ac/nfephp-org-sped-nfe-8a8283e/scheme   
  s/PL_009_V4/eventoCancEntregaNFe_v1.00.xsd): failed to open stream: File exists