### PR TITLE
Acerto do campo $std->cAgreg para aceitar alpha

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -2329,7 +2329,7 @@ class Make
         $this->dom->addChild(
             $rastro,
             "cAgreg",
-            Strings::onlyNumbers($std->cAgreg),
+            $std->cAgreg,
             false,
             $identificador . "[item $std->item] Código de Agregação"
         );


### PR DESCRIPTION
Conforme NT 2020.005 v1.20, item 2.1.3, será necessário mudança no componente para envio de NF-es de itens com lotes.

"2.1.3. Alteração do Campo cAgreg para Alfanumérico (Grupo I80)
A NT2016.002 introduziu o grupo I80 para permitir a rastreabilidade de qualquer produto sujeito a regulações sanitárias. Observou-se a necessidade de alterar o campo onde se informa o Código de Agregação (cAgreg – I85) de numérico para alfanumérico".