### PR TITLE
Totalização automática do grupo ISSQNTot em documentos Conjugados (Produto + Serviços)

### DIFF
--- a/examples/NFCeConjugada.php
+++ b/examples/NFCeConjugada.php
@@ -1,0 +1,292 @@
+<?php
+
+error_reporting(E_ERROR);
+ini_set('display_errors', 'On');
+require_once '../bootstrap.php';
+
+use NFePHP\NFe\Tools;
+use NFePHP\NFe\Make;
+use NFePHP\Common\Certificate;
+use NFePHP\Common\Soap\SoapFake;
+
+$arr = [
+    "atualizacao" => "2017-02-20 09:11:21",
+    "tpAmb"       => 2,
+    "razaosocial" => "SUA RAZAO SOCIAL LTDA",
+    "cnpj"        => "99999999999999",
+    "siglaUF"     => "SP",
+    "schemes"     => "PL_009_V4",
+    "versao"      => '4.00',
+    "tokenIBPT"   => "AAAAAAA",
+    "CSC"         => "GPB0JBWLUR6HWFTVEAS6RJ69GPCROFPBBB8G",
+    "CSCid"       => "000001",
+    "proxyConf"   => [
+        "proxyIp"   => "",
+        "proxyPort" => "",
+        "proxyUser" => "",
+        "proxyPass" => ""
+    ]
+];
+$configJson = json_encode($arr);
+$pfxcontent = file_get_contents('fixtures/expired_certificate.pfx');
+
+$tools = new Tools($configJson, Certificate::readPfx($pfxcontent, 'associacao'));
+//$tools->disableCertValidation(true); //tem que desabilitar
+$tools->model('65');
+
+try {
+
+    $make = new Make();
+
+    //infNFe OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->Id = '';
+    $std->versao = '4.00';
+    $infNFe = $make->taginfNFe($std);
+
+    //ide OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->cUF = 14;
+    $std->cNF = '03701267';
+    $std->natOp = 'VENDA CONSUMIDOR';
+    $std->mod = 65;
+    $std->serie = 1;
+    $std->nNF = 100;
+    $std->dhEmi = (new \DateTime())->format('Y-m-d\TH:i:sP');
+    $std->dhSaiEnt = null;
+    $std->tpNF = 1;
+    $std->idDest = 1;
+    $std->cMunFG = 1400100;
+    $std->tpImp = 1;
+    $std->tpEmis = 1;
+    $std->cDV = 2;
+    $std->tpAmb = 2;
+    $std->finNFe = 1;
+    $std->indFinal = 1;
+    $std->indPres = 1;
+    $std->procEmi = 3;
+    $std->verProc = '4.13';
+    $std->dhCont = null;
+    $std->xJust = null;
+    $ide = $make->tagIde($std);
+
+    //emit OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->xNome = 'SUA RAZAO SOCIAL LTDA';
+    $std->xFant = 'RAZAO';
+    $std->IE = '111111111';
+    $std->IEST = null;
+    //$std->IM = '95095870';
+    $std->CNAE = '4642701';
+    $std->CRT = 1;
+    $std->CNPJ = '99999999999999';
+    //$std->CPF = '12345678901'; //NÃO PASSE TAGS QUE NÃO EXISTEM NO CASO
+    $emit = $make->tagemit($std);
+
+    //enderEmit OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->xLgr = 'Avenida Getúlio Vargas';
+    $std->nro = '5022';
+    $std->xCpl = 'LOJA 42';
+    $std->xBairro = 'CENTRO';
+    $std->cMun = 1400100;
+    $std->xMun = 'BOA VISTA';
+    $std->UF = 'RR';
+    $std->CEP = '69301030';
+    $std->cPais = 1058;
+    $std->xPais = 'Brasil';
+    $std->fone = '55555555';
+    $ret = $make->tagenderemit($std);
+
+    //dest OPCIONAL
+    $std = new \stdClass();
+    $std->xNome = 'Eu Ltda';
+    $std->CNPJ = '01234123456789';
+    //$std->CPF = '12345678901';
+    //$std->idEstrangeiro = 'AB1234';
+    $std->indIEDest = 9;
+    //$std->IE = '';
+    //$std->ISUF = '12345679';
+    //$std->IM = 'XYZ6543212';
+    $std->email = 'seila@seila.com.br';
+    $dest = $make->tagdest($std);
+
+    //enderDest OPCIONAL
+    $std = new \stdClass();
+    $std->xLgr = 'Avenida Sebastião Diniz';
+    $std->nro = '458';
+    $std->xCpl = null;
+    $std->xBairro = 'CENTRO';
+    $std->cMun = 1400100;
+    $std->xMun = 'Boa Vista';
+    $std->UF = 'RR';
+    $std->CEP = '69301088';
+    $std->cPais = 1058;
+    $std->xPais = 'Brasil';
+    $std->fone = '1111111111';
+    $ret = $make->tagenderdest($std);
+
+    //prod OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->item = 1;
+    $std->cProd = '00341';
+    $std->cEAN = 'SEM GTIN';
+    $std->cEANTrib = 'SEM GTIN';
+    $std->xProd = 'Produto com serviço';
+    $std->NCM = '96081000';
+    $std->CFOP = '5933';
+    $std->uCom = 'JG';
+    $std->uTrib = 'JG';
+    $std->cBarra = NULL;
+    $std->cBarraTrib = NULL;
+    $std->qCom = '1';
+    $std->qTrib = '1';
+    $std->vUnCom = '2';
+    $std->vUnTrib = '2';
+    $std->vProd = '2';
+    $std->vDesc = NULL;
+    $std->vOutro = NULL;
+    $std->vSeg = NULL;
+    $std->vFrete = NULL;
+    $std->cBenef = NULL;
+    $std->xPed = NULL;
+    $std->nItemPed = NULL;
+    $std->indTot = 1;
+
+    // Monta a tag de impostos mas não adiciona no xml
+    $ISSQN = new stdClass();
+    $ISSQN->item = 1; //item da NFe
+    $ISSQN->vBC = 2.0;
+    $ISSQN->vAliq = 8.0;
+    $ISSQN->vISSQN = 0.16;
+    $ISSQN->cMunFG = 1300029;
+    $ISSQN->cMun = 1300029;
+    $ISSQN->cPais = '1058';
+    $ISSQN->cListServ = '01.01';
+    $ISSQN->indISS = 1;
+    $ISSQN->indIncentivo = 2;
+
+    // Aqui está a mudança principal, informar a tag imposto para totalizar o valor do serviço automaticamente
+    $prod = $make->tagprod($std, $ISSQN);
+
+    //Imposto
+    $std = new stdClass();
+    $std->item = 1; //item da NFe
+    $std->vTotTrib = 0;
+    $make->tagimposto($std);
+
+    // Adiciona a tag de imposto ISSQN no xml
+    $make->tagISSQN($ISSQN);
+
+    //Imposto
+    $std = new stdClass();
+    $std->item = 1; //item da NFe
+    $std->vTotTrib = 0;
+    $make->tagimposto($std);
+
+    // Item 2
+    //prod OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->item = 2; //item da NFe
+    $std->cProd = '00065';
+    $std->cEAN = 'SEM GTIN';
+    $std->cEANTrib = 'SEM GTIN';
+    $std->xProd = 'Coca Cola Lata 350 ml';
+    $std->NCM = '22021000';
+    $std->CFOP = '5101';
+    $std->uCom = 'LAT';
+    $std->uTrib = 'LAT';
+    $std->cBarra = NULL;
+    $std->cBarraTrib = NULL;
+    $std->qCom = '1';
+    $std->qTrib = '1';
+    $std->vUnCom = '0.01';
+    $std->vUnTrib = '0.01';
+    $std->vProd = '0.01';
+    $std->vDesc = NULL;
+    $std->vOutro = NULL;
+    $std->vSeg = NULL;
+    $std->vFrete = NULL;
+    $std->cBenef = NULL;
+    $std->xPed = NULL;
+    $std->nItemPed = NULL;
+    $std->indTot = 1;
+
+    // Como aqui se trata de um produto comum, não precisa passar a tag do imposto para a tag prod
+    $prod = $make->tagprod($std);
+
+    //Imposto
+    $std = new stdClass();
+    $std->item = 2; //item da NFe
+    $std->vTotTrib = 0;
+    $make->tagimposto($std);
+
+    $std = new stdClass();
+    $std->item = 2; //item da NFe
+    $std->orig = '7';
+    $std->CST = '41';
+    $std->vICMS = 0.0008;
+    $std->pICMS = 8.0;
+    $std->vBC = 0.01;
+    $std->modBC = '3';
+    $std->pFCP = NULL;
+    $std->vFCP = NULL;
+    $std->vBCFCP = NULL;
+    $std->pRedBC = 0.0;
+    $make->tagICMS($std);
+
+    //PIS
+    $std = new stdClass();
+    $std->item = 2; //item da NFe
+    $std->CST = '99';
+    $std->vBC = 0.01;
+    $std->pPIS = 0.0;
+    $std->vPIS = 0.0;
+    $pis = $make->tagPIS($std);
+
+    //COFINS
+    $std = new stdClass();
+    $std->item = 2; //item da NFe
+    $std->CST = '99';
+    $std->vBC = 0.01;
+    $std->pCOFINS = 0.0;
+    $std->vCOFINS = 0.0;
+    $make->tagCOFINS($std);
+
+    //transp OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->modFrete = 0;
+    $transp = $make->tagtransp($std);
+
+    //pag OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->vTroco = 0;
+    $pag = $make->tagpag($std);
+
+    //detPag OBRIGATÓRIA
+    $std = new \stdClass();
+    $std->indPag = '0';
+    $std->xPag = NULL;
+    $std->tPag = '01';
+    $std->vPag = 2.01;
+    $detpag = $make->tagdetpag($std);
+
+    $std = new stdClass();
+    $std->CNPJ = '99999999999999'; //CNPJ da pessoa jurídica responsável pelo sistema utilizado na emissão do documento fiscal eletrônico
+    $std->xContato = 'Fulano de Tal'; //Nome da pessoa a ser contatada
+    $std->email = 'fulano@soft.com.br'; //E-mail da pessoa jurídica a ser contatada
+    $std->fone = '1155551122'; //Telefone da pessoa jurídica/física a ser contatada
+    //$std->CSRT = 'G8063VRTNDMO886SFNK5LDUDEI24XJ22YIPO'; //Código de Segurança do Responsável Técnico
+    //$std->idCSRT = '01'; //Identificador do CSRT
+    $make->taginfRespTec($std);
+
+    $make->monta();
+    $xml = $make->getXML();
+
+    $xml = $tools->signNFe($xml);
+
+    header('Content-Type: application/xml; charset=utf-8');
+    echo $xml;
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}


### PR DESCRIPTION
Adicionado a implementação de totalização do grupo ISSQNTot.

> Pontos positivos
- A biblioteca irá totalizar os valores da tag ISSQN de cada item no grupo ISSQNTot de maneira automática (assim como a ICMSTot).

> Pontos negativos
- O uso da funcionalidade fica um pouco fora do padrão de uso da biblioteca, se acaso for achado um jeito melhor de fazer isso podemos alterar.

Basicamente para diferenciar um produto de um serviço no XML, é que um serviço possui a tag imposto > ISSQN enquanto um produto possui a tag imposto > (ICMS|ICMSSN).

O problema é que o valor do produto/serviço (prod > vProd) ficam dentro da tag prod, fora do escopo da totalização dos impostos, e nessa tag não tem nenhuma informação que diz se o item é produto ou serviço. 

A solução que encontrei, é informar para a tag prod, a std que contém o valor da base do ISS e o valor do ISS, assim podemos identificar que possui a tag vISSQN, que é exclusiva para Serviços.

Para um item do tipo Produto (ICMS ou ICMSSN), não é necessário informar o segundo parâmetro da função, ou seja, tudo irá funcionar como antes.

O trecho a seguir faz a distinção entre um produto e um serviço

```php
    // prod OBRIGATÓRIA
    $std = new \stdClass();
    $std->item = 1;
    $std->cProd = '00341';
    $std->cEAN = 'SEM GTIN';
    $std->cEANTrib = 'SEM GTIN';
    $std->xProd = 'Produto com serviço';
    $std->NCM = '00';
    $std->CFOP = '5933';
    $std->uCom = 'JG';
    $std->uTrib = 'JG';
    $std->cBarra = NULL;
    $std->cBarraTrib = NULL;
    $std->qCom = '1';
    $std->qTrib = '1';
    $std->vUnCom = '2';
    $std->vUnTrib = '2';
    $std->vProd = '2';
    $std->vDesc = NULL;
    $std->vOutro = NULL;
    $std->vSeg = NULL;
    $std->vFrete = NULL;
    $std->cBenef = NULL;
    $std->xPed = NULL;
    $std->nItemPed = NULL;
    $std->indTot = 1;

    // Monta a tag de impostos mas não adiciona no xml
    $ISSQN = new stdClass();
    $ISSQN->item = 1; // item da NFe
    $ISSQN->vBC = 2.0;
    $ISSQN->vAliq = 8.0;
    $ISSQN->vISSQN = 0.16;
    $ISSQN->cMunFG = 1300029;
    $ISSQN->cMun = 1300029;
    $ISSQN->cPais = '1058';
    $ISSQN->cListServ = '01.01';
    $ISSQN->indISS = 1;
    $ISSQN->indIncentivo = 2;

    // Aqui está a mudança principal, informar a tag imposto para totalizar o valor do serviço automaticamente
    // Para um item do tipo Produto (ICMS ou ICMSSN), não é necessário informar o segundo parâmetro, ou seja, tudo irá funcionar como antes.
    $prod = $make->tagprod($std, $ISSQN);

    // Imposto
    $std = new stdClass();
    $std->item = 1; //item da NFe
    $std->vTotTrib = 0;
    $make->tagimposto($std);

    // Adiciona a tag de imposto ISSQN no xml
    $make->tagISSQN($ISSQN);
```