### PR TITLE
Adicionando novas dependências e removendo phpcpd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     name: Testes Automatizados
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         if: matrix.php-version == '7.0' || matrix.php-version == '7.1'
         run: composer require "phpunit/phpunit:^6.0" -W --dev
 
+      - name: Uninstall phpstan on unsupported php version
+        if: matrix.php-version == '7.0'
+        run: composer remove phpstan/phpstan --dev
+
       - name: Composer Install
         run: |
           composer install --no-progress -o --no-ansi --no-interaction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Pipeline para o admin
+name: Pipeline
 on:
   push:
     branches:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4']
+        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - setup-phpstan
+      - alterando-dependencias
 
   pull_request:
     branches:
@@ -28,13 +28,13 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Set phpunit version
-        if: matrix.php-version == '7.0' || matrix.php-version == '7.1'
-        run: composer require "phpunit/phpunit:^6.0" -W --dev
-
       - name: Uninstall phpstan on unsupported php version
         if: matrix.php-version == '7.0'
         run: composer remove phpstan/phpstan --dev
+
+      - name: Set phpunit version
+        if: matrix.php-version == '7.0' || matrix.php-version == '7.1'
+        run: composer require "phpunit/phpunit:^6.0" -W --dev
 
       - name: Composer Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
 
     steps:
       - name: Setup PHP
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set phpunit version
         if: matrix.php-version == '7.0' || matrix.php-version == '7.1'
-        run: composer require "phpunit/phpunit:^7.5" -W --dev
+        run: composer require "phpunit/phpunit:^6.0" -W --dev
 
       - name: Composer Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,16 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Set phpunit version
+        if: matrix.php-version == '7.0' || matrix.php-version == '7.1'
+        run: composer require "phpunit/phpunit:^7.5" -W --dev
+
       - name: Composer Install
         run: |
           composer install --no-progress -o --no-ansi --no-interaction
 
       - name: Análises estáticas
+        if: matrix.php-version != '7.0' && matrix.php-version != '7.1'
         run: |
           composer stan
 

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
         "ext-libxml": "*"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.4",
-        "phpunit/phpunit": "^7.5",
+        "squizlabs/php_codesniffer": "*",
+        "phpunit/phpunit": "^8.0",
         "scrutinizer/ocular": "^1.3",
-        "sebastian/phpcpd": "^4.1",
-        "phpstan/phpstan": "^0.12.99"
+        "phpstan/phpstan": "^0.12.99",
+        "phpcompatibility/php-compatibility": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "*",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^6",
         "scrutinizer/ocular": "^1.3",
         "phpstan/phpstan": "^0.12.99",
         "phpcompatibility/php-compatibility": "^9.3"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="CakePHPSniffer">
+    <description>sped-nfe</description>
+
+    <arg name="extensions" value="php"/>
+    <config name="testVersion" value="7.0-8.0"/>
+
+    <config name="installed_paths" value="vendor/phpcompatibility/php-compatibility" />
+
+    <rule  ref="PSR12" />
+</ruleset>

--- a/tests/Common/WebservicesTest.php
+++ b/tests/Common/WebservicesTest.php
@@ -23,7 +23,7 @@ class WebservicesTest extends TestCase
      */
     protected $xml;
 
-    protected function setUp(): void
+    protected function setUp()
     {
         $filepath = __DIR__ . '/../../storage/wsnfe_4.00_mod55.xml';
         $this->xml = file_get_contents($filepath);

--- a/tests/MakeTest.php
+++ b/tests/MakeTest.php
@@ -231,7 +231,7 @@ class MakeTest extends TestCase
         $this->assertEmpty($ide->getElementsByTagName('xJust')->item(0));
     }
 
-    protected function setUp(): void
+    protected function setUp()
     {
         $this->make = new Make();
     }

--- a/tests/ToolsTest.php
+++ b/tests/ToolsTest.php
@@ -14,7 +14,7 @@ class ToolsTest extends NFeTestCase
      */
     protected $tools;
 
-    protected function setUp(): void
+    protected function setUp()
     {
         $this->tools = new Tools(
             $this->configJson,


### PR DESCRIPTION
A biblioteca phpcpd é recomendada usar o phar que eles disponibilizam, não como dependência.
As demais bibliotecas são necessárias para padronizarmos o código. Depois vou incluir elas no pipeline do github.