### PR TITLE
Inclusão da inutilização de NFe com CPF, exclusivo para MT

### DIFF
--- a/fake/fakeSefazInutiliza_CPF_MT.php
+++ b/fake/fakeSefazInutiliza_CPF_MT.php
@@ -1,0 +1,55 @@
+<?php
+
+error_reporting(E_ALL);
+ini_set('display_errors', 'On');
+require_once '../bootstrap.php';
+
+use NFePHP\NFe\Tools;
+use NFePHP\Common\Certificate;
+use NFePHP\Common\Soap\SoapFake;
+use NFePHP\NFe\Common\FakePretty;
+
+try {
+
+    $arr = [
+        "atualizacao" => "2016-11-03 18:01:21",
+        "tpAmb"       => 2,
+        "razaosocial" => "SUA RAZAO SOCIAL LTDA",
+        "cnpj"        => "12345678901",
+        "siglaUF"     => "MT",
+        "schemes"     => "PL_009_V4",
+        "versao"      => '4.00',
+        "tokenIBPT"   => "AAAAAAA",
+        "CSC"         => "GPB0JBWLUR6HWFTVEAS6RJ69GPCROFPBBB8G",
+        "CSCid"       => "000001",
+        "proxyConf"   => [
+            "proxyIp"   => "",
+            "proxyPort" => "",
+            "proxyUser" => "",
+            "proxyPass" => ""
+        ]
+    ];
+    $configJson = json_encode($arr);
+    $soap = new SoapFake();
+    $soap->disableCertValidation(true);
+
+    $content = file_get_contents('expired_certificate.pfx');
+    $tools = new Tools($configJson, Certificate::readPfx($content, 'associacao'));
+    $tools->model('55');
+    $tools->setVerAplic('5.1.34');
+    $tools->loadSoapClass($soap);
+    
+    $nSerie = 1;
+    $nIni = 23;
+    $nFin = 24;
+    $xJust = "Falha no registro do aplicativo";
+    $tpAmb = null;
+    $ano = null; //para anos anteriores
+
+    $response = $tools->sefazInutiliza($nSerie, $nIni, $nFin, $xJust, $tpAmb, $ano);
+
+    echo FakePretty::prettyPrint($response);
+    
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/schemes/PL_009_V4/MT_inutNFe_v4.00.xsd
+++ b/schemes/PL_009_V4/MT_inutNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteInutNFe_v4.00_MT.xsd"/>
+	<xs:element name="inutNFe" type="TInutNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/schemes/PL_009_V4/leiauteInutNFe_v4.00_MT.xsd
+++ b/schemes/PL_009_V4/leiauteInutNFe_v4.00_MT.xsd
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  PL_006f versao com correcoes no xServ para tornar a literal INUTILIZAR obrigatoria 21/05/2010 -->
+<!--  PL_006c versao com correcoes 24/12/2009 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:complexType name="TInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infInut">
+				<xs:annotation>
+					<xs:documentation>Dados do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xServ">
+							<xs:annotation>
+								<xs:documentation>Serviço Solicitado</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TServ">
+									<xs:enumeration value="INUTILIZAR"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>Código da UF do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ano" type="Tano">
+							<xs:annotation>
+								<xs:documentation>Ano de inutilização da numeração</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:choice>
+                                                    <xs:element name="CNPJ" type="TCnpj">
+							<xs:annotation>
+                                                            <xs:documentation>Número do CNPJ do emitente</xs:documentation>
+							</xs:annotation>
+                                                    </xs:element>
+                                                    <xs:element name="CPF" type="TCpf">
+							<xs:annotation>
+                                                            <xs:documentation>Número do CPF do emitente</xs:documentation>
+							</xs:annotation>
+                                                    </xs:element>
+						</xs:choice>
+						<xs:element name="mod" type="TMod">
+							<xs:annotation>
+								<xs:documentation>Modelo da NF-e (55, 65 etc.)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="serie" type="TSerie">
+							<xs:annotation>
+								<xs:documentation>Série da NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFIni" type="TNF">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e inicial</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFFin" type="TNF">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e final</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xJust" type="TJust">
+							<xs:annotation>
+								<xs:documentation>Justificativa do pedido de inutilização</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{41}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infInut">
+				<xs:annotation>
+					<xs:documentation>Dados do Retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>Código da UF que atendeu a solicitação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ano" type="Tano" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Ano de inutilização da numeração</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="CNPJ" type="TCnpj" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>CNPJ do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="mod" type="TMod" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Modelo da NF-e (55, etc.)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="serie" type="TSerie" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Série da NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFIni" type="TNF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e inicial</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFFin" type="TNF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e final</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de recebimento, no formato AAAA-MM-DDTHH:MM:SS. Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação. Em caso de Rejeição, com data e hora do recebimento do Pedido de Inutilização.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - código da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TProcInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de inutilzação de númeração de  NF-e processado</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="inutNFe" type="TInutNFe"/>
+			<xs:element name="retInutNFe" type="TRetInutNFe"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do leiaute de Inutilização 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -210,7 +210,7 @@ class Tools extends ToolsCommon
         $idInut = "ID"
             . $this->urlcUF
             . $strAno
-            . $cnpj
+            . str_pad($cnpj, 14, '0', STR_PAD_LEFT)
             . $this->modelo
             . $strSerie
             . $strInicio
@@ -231,6 +231,25 @@ class Tools extends ToolsCommon
             "<nNFFin>$nFin</nNFFin>" .
             "<xJust>$xJust</xJust>" .
             "</infInut></inutNFe>";
+        //inutizaçao para produtor rural com CPF em MT
+        $flag = false;
+        if ($this->config->siglaUF == 'MT' && strlen($cnpj) == 11) {
+            //montagem do corpo da mensagem
+            $msg = "<inutNFe xmlns=\"$this->urlPortal\" versao=\"$this->urlVersion\">" .
+                "<infInut Id=\"$idInut\">" .
+                "<tpAmb>$tpAmb</tpAmb>" .
+                "<xServ>INUTILIZAR</xServ>" .
+                "<cUF>$this->urlcUF</cUF>" .
+                "<ano>$strAno</ano>" .
+                "<CPF>$cnpj</CPF>" .
+                "<mod>$this->modelo</mod>" .
+                "<serie>$nSerie</serie>" .
+                "<nNFIni>$nIni</nNFIni>" .
+                "<nNFFin>$nFin</nNFFin>" .
+                "<xJust>$xJust</xJust>" .
+                "</infInut></inutNFe>";
+            $flag = true;
+        }
         //assina a solicitação
         $request = Signer::sign(
             $this->certificate,
@@ -241,7 +260,11 @@ class Tools extends ToolsCommon
             $this->canonical
         );
         $request = Strings::clearXmlString($request, true);
-        $this->isValid($this->urlVersion, $request, 'inutNFe');
+        if (!$flag) {
+            $this->isValid($this->urlVersion, $request, 'inutNFe');
+        } else {
+            $this->isValid($this->urlVersion, $request, 'MT_inutNFe');
+        }
         $this->lastRequest = $request;
         $parameters = ['nfeDadosMsg' => $request];
         $body = "<nfeDadosMsg xmlns=\"$this->urlNamespace\">$request</nfeDadosMsg>";


### PR DESCRIPTION
Preliminarmente, comunicamos que, em face da publicação da Portaria Nº 160/2021 (abaixo reproduzida), o prazo para os Produtores Rurais promover a inutilização de faixas de números não utilizados foi estendido até **30/11/2021**;

PORTARIA N° 160/2021-SEFAZ MT

Art. 33 O contribuinte deverá solicitar a inutilização dos números de NF-e não utilizados, até o 10° (décimo) dia do mês subsequente ao da respectiva geração, mediante Pedido de Inutilização de Número da NF-e, na eventualidade de quebra de sequência da numeração da NF-e.

§ 6° Em caráter excepcional, quando o emitente de NF-e for pessoa física, fica autorizada a regularização em relação a eventuais quebras de sequência identificadas até a data da publicação desta portaria, hipóteses em que o Pedido de Inutilização do Número da NF-e deverá ser formalizado até o dia 30 de novembro de 2021, mediante observância do disposto nos §§ 1° a 3° deste artigo.

Considerações:

A inutilização não é feita através de processo;

- Se o sistema do produtor primário ainda não estiver preparado para efetuar a inutilização o mesmo terá que solicitar ao seu fornecedor do programa emissor, que faça as adequações (substituir a tag CNPJ pela tag CPF);
- O sistema da SEFAZ/MT já está recebendo inutilizações há meses;
- Embora a inutilização não esteja prevista nacionalmente (em nota técnica nacional), este estado já desenvolveu a Inutilização para Pessoa Física (CPF).