### PR TITLE
Ajustes da totalização automática do ISSQNtot

### DIFF
--- a/examples/NFCeConjugada.php
+++ b/examples/NFCeConjugada.php
@@ -170,6 +170,24 @@ try {
     // Adiciona a tag de imposto ISSQN no xml
     $make->tagISSQN($std);
 
+    //PIS
+    $std = new stdClass();
+    $std->item = 1; //item da NFe
+    $std->CST = '99';
+    $std->vBC = 2.0;
+    $std->pPIS = 10.0;
+    $std->vPIS = 0.20;
+    $pis = $make->tagPIS($std);
+
+    //COFINS
+    $std = new stdClass();
+    $std->item = 1; //item da NFe
+    $std->CST = '99';
+    $std->vBC = 2.0;
+    $std->pCOFINS = 10.0;
+    $std->vCOFINS = 0.20;
+    $make->tagCOFINS($std);
+
     //Imposto
     $std = new stdClass();
     $std->item = 1; //item da NFe
@@ -232,8 +250,8 @@ try {
     $std->item = 2; //item da NFe
     $std->CST = '99';
     $std->vBC = 0.01;
-    $std->pPIS = 0.0;
-    $std->vPIS = 0.0;
+    $std->pPIS = 100;
+    $std->vPIS = 0.01;
     $pis = $make->tagPIS($std);
 
     //COFINS
@@ -241,8 +259,8 @@ try {
     $std->item = 2; //item da NFe
     $std->CST = '99';
     $std->vBC = 0.01;
-    $std->pCOFINS = 0.0;
-    $std->vCOFINS = 0.0;
+    $std->pCOFINS = 100;
+    $std->vCOFINS = 0.01;
     $make->tagCOFINS($std);
 
     //transp OBRIGATÓRIA
@@ -271,6 +289,16 @@ try {
     //$std->CSRT = 'G8063VRTNDMO886SFNK5LDUDEI24XJ22YIPO'; //Código de Segurança do Responsável Técnico
     //$std->idCSRT = '01'; //Identificador do CSRT
     $make->taginfRespTec($std);
+
+    // TESTE DE CONSIDERAR O VALOR INFORMADO NESSA TAG DE TOTAL ANTES DE CONSIDERAR A TOTALIZADA PELA CLASSE
+    // $teste = new \stdClass;
+    // $teste->vProd = 200;
+    // $make->tagICMSTot($teste);
+
+    // TESTE DE CONSIDERAR O VALOR INFORMADO NESSA TAG DE TOTAL ANTES DE CONSIDERAR A TOTALIZADA PELA CLASSE
+    // $teste = new \stdClass;
+    // $teste->vServ = 200;
+    // $make->tagISSQNTot($teste);
 
     $make->monta();
     $xml = $make->getXML();

--- a/src/Make.php
+++ b/src/Make.php
@@ -7742,12 +7742,15 @@ class Make
     /**
      * Função que adiciona o valor da tag no total dos impostos, com base no tipo do item (produto ou serviço)
      *
-     * Por exemplo, quero totalizar o PIS e COFINS dos itens, eu chamo essa função e a mesma confere se o item em questão é um produto ou um serviço
+     * Por exemplo, quer totalizar o PIS e COFINS dos itens:
+     * chame essa função e a mesma confere se o item em questão é um produto ou um serviço
      */
     private function totaliza($item, $tag, $valor)
     {
 
-        if (!array_key_exists($item, $this->itens)) return;
+        if (!array_key_exists($item, $this->itens)) {
+            return;
+        }
 
         $tipo = $this->itens[$item]['tipo'] ?? null;
 
@@ -7775,14 +7778,11 @@ class Make
 
         // se houver o valor do item (apenas se o indTot=1)
         if ($vlr = $it['valor'] ?? null) {
-
             // se for um produto
             if ($tipo === 'produto') {
                 $this->stdICMSTot->vProd += $vlr;
-            }
-
-            // se for serviço
-            else {
+            } else {
+                // se for serviço
                 $this->stdISSQNtot->vServ += $vlr;
             }
         }

--- a/src/Make.php
+++ b/src/Make.php
@@ -297,16 +297,16 @@ class Make
     /**
      * @var DOMElement
      */
-    protected $ICMSTot;
+    protected $ICMSTot = null;
     /**
      * @var DOMElement
      */
-    protected $ISSQNtot;
+    protected $ISSQNtot = null;
 
     /**
      * Itens que possuem tributação de ISSQN (serviços)
      * [nItem => {tipo: string(servico|produto), valor: float}]
-     * @var \stdClass[]
+     * @var array<mixed, mixed>
      */
     protected $itens = [];
 
@@ -463,7 +463,7 @@ class Make
         $this->dom->appChild($this->total, $this->ICMSTot, '');
 
         // Força a construção do total de issqn se houver valor de serviço e se a tag ainda não foi criada
-        if ($this->stdISSQNtot->vServ && !$this->ISSQNtot) {
+        if ($this->stdISSQNtot->vServ > 0 && $this->ISSQNtot == null) {
             $std = new \stdClass();
             $this->tagISSQNTot($std);
         }


### PR DESCRIPTION
Esse PR foi criado com base no PR #868 

1. Foi criado 3 atributos novos na classe
- ICMSTot: Grupo da tag criado apenas na memória, ainda não adicionado no XML;
- ISSQNtot: Grupo da tag criado apenas na memória, ainda não adicionado no XML;
- itens: Para cada vez que é chamado a tagprod, é criado um índice nesse array, que armazena o vProd (se indTot = 1). O vProd é armazenado nesse array para posteriormente decidir se esse valor irá para ICMSTot>vProd ou para a ISSQNtot>vServ;

2. Foi alterado a rotina de montar o XML, para evitar duplicar tags de ICMSTot ou ISSQNtot, agora só vai criar a tag no momento de montar o xml (no método monta()) e não mais no momento da chamada da tagICMSTot ou da ISSQNtot;

3. Foi alterado o atributo stdTot para stdICMSTot, já que esse totalizador é próprio de produtos;

4. Foi criado um método chamado totaliza (item, tag, valor), que vai totalizar uma tag específica com base no tpo do item. Por exemplo, PIS e COFINS totalizam separadamente tanto para produto quanto para serviços, então essa função vai diferenciar um produto e um serviço e vai informar o vPIS para o seu destino correto;

5. Foi adicionado a função inicializaItem(item, tipo), que vai iniciar o item no array itens e vai guardar o tipo desse item (produto|servico). Essa função é chamada pela tag que destaca o imposto do item (ICMS|ICMSSN|ISSQN), e aqui é usado o índice valor (criado lá na tagprod), que vai totalizar no lugar correto.

Sei que são muitas alterações, mas elas terão impacto baixo para quem usa, tanto que no exemplo NFCeConjugada.php eu só adicionei o PIS e COFINS no item do serviço e testei informar valores manuais em abas as tags ICMSTot e ISSQNtot.

Qualquer dúvida estou à disposição.