### PR TITLE
Ajuste somar vICMS no CST 51

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -3411,6 +3411,7 @@ class Make
                 break;
             case '51':
                 $this->stdTot->vBC += (float) !empty($std->vBC) ? $std->vBC : 0;
+                $this->stdTot->vICMS += (float) !empty($std->vICMS) ? $std->vICMS : 0;
 
                 $icms = $this->dom->createElement("ICMS51");
                 $this->dom->addChild(


### PR DESCRIPTION
Há tempos atrás foi aberto uma ISSUE (#727) sobre essa situação, dizia que a NT 2010_010 (pág 16), porém se tento autorizar uma NF-e com o CST 51 destacado, retorna a Rejeicao 532: Total do ICMS difere do somatorio dos itens.

Tentei colocar fixo na tag ICMSTot o valor do ICMS correspondente ao vICMS destacado no item do CST 51 e a SEFAZ autorizou.

Infelizmente não encontrei nenhuma NT que anula a citada acima, porém a validação dela não condiz com a prática na SEFAZ.

![image](https://user-images.githubusercontent.com/77071812/142058819-2f832579-c937-4f4d-80f8-e09a9c7a9997.png)
![image](https://user-images.githubusercontent.com/77071812/142058887-1f2e46ff-cbde-4d8c-b2cf-67047002d01b.png)

Se eu fixo o valor na ICMSTot:

![image](https://user-images.githubusercontent.com/77071812/142059004-14ed0a8c-cce2-4a7f-97df-a48aff8e59b6.png)

A SEFAZ autoriza sem problemas