### PR TITLE
Atualização de servidor de ce para svrs no modelo 55.

### DIFF
--- a/storage/autorizadores.json
+++ b/storage/autorizadores.json
@@ -36,7 +36,7 @@
         "AN": "AN",
         "AP": "SVRS",
         "BA": "BA",
-        "CE": "CE",
+        "CE": "SVRS",
         "DF": "SVRS",
         "ES": "SVRS",
         "GO": "GO",


### PR DESCRIPTION
De acordo com a noticia publicada no site da sefaz do CE, a mudança de servidor ocorrera apartir do dia 10 de janeiro as 9 horas com o ambiente de produção, o de homologação ja esta disponivel.


_A Secretaria da Fazenda do Ceará (Sefaz-CE) informa que, a partir do dia 10 de janeiro de 2022, às 9 horas, as Notas Fiscais Eletrônicas (NF-e) emitidas por contribuintes do Ceará passarão a ser autorizadas por meio da Sefaz Virtual do Rio Grande do Sul (SVRS).

Com a mudança no ambiente de autorização dos documentos fiscais eletrônicos modelo 55 no Ceará, os contribuintes obrigados à emissão de NF-e deverão fazer a adaptação no sistema emissor, já que o ambiente antigo de autorização será desativado._

Link da noticia:[https://www.sefaz.ce.gov.br/2021/12/08/comunicado-nfe-migracao-para-svrs/](Site Sefaz CEl)