### PR TITLE
Reativando PHPStan e corrigindo teste desnecessário

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Check php code style
         run: composer phpcs
 
+      - name: Análises estáticas
+        run: |
+          composer stan
+
       - name: Rodando PHPUnit
         run: |
           composer test

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: src/Common/Tools.php
 
 		-
-			message: "#^Parameter \\#1 \\$code of static method NFePHP\\\\Common\\\\UFList\\:\\:getUFByCode\\(\\) expects int, string given\\.$#"
-			count: 2
-			path: src/Common/Tools.php
-
-		-
 			message: "#^Parameter \\#1 \\$version of static method NFePHP\\\\NFe\\\\Common\\\\ValidTXT\\:\\:loadStructure\\(\\) expects float, string given\\.$#"
 			count: 1
 			path: src/Common/ValidTXT.php
@@ -44,11 +39,6 @@ parameters:
 			message: "#^Variable \\$tpEmis might not be defined\\.$#"
 			count: 1
 			path: src/Factories/Contingency.php
-
-		-
-			message: "#^Parameter \\#1 \\$code of static method NFePHP\\\\Common\\\\UFList\\:\\:getUFByCode\\(\\) expects int, string given\\.$#"
-			count: 1
-			path: src/Factories/ContingencyNFe.php
 
 		-
 			message: "#^Method NFePHP\\\\NFe\\\\Make\\:\\:conditionalNumberFormatting\\(\\) should return string but returns null\\.$#"

--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -331,7 +331,7 @@ class Tools
     public function validKeyByUF($chave)
     {
         $uf = $this->config->siglaUF;
-        if ($uf != UFList::getUFByCode(substr($chave, 0, 2))) {
+        if ($uf != UFList::getUFByCode((int)substr($chave, 0, 2))) {
             throw new \InvalidArgumentException(
                 "A chave da NFe indicada [$chave] não pertence a [$uf]."
             );
@@ -564,7 +564,7 @@ class Tools
         $this->modelo = 65;
         $cUF = $dom->getElementsByTagName('cUF')->item(0)->nodeValue;
         $tpAmb = $dom->getElementsByTagName('tpAmb')->item(0)->nodeValue;
-        $uf = UFList::getUFByCode($cUF);
+        $uf = UFList::getUFByCode((int)$cUF);
         $this->servico('NfeConsultaQR', $uf, $tpAmb);
         $signed = QRCode::putQRTag(
             $dom,

--- a/src/Factories/ContingencyNFe.php
+++ b/src/Factories/ContingencyNFe.php
@@ -47,7 +47,7 @@ class ContingencyNFe
         }
         $motivo = trim(Strings::replaceUnacceptableCharacters($contingency->motive));
 
-        $tz = TimeZoneByUF::get(UFList::getUFByCode($cUF));
+        $tz = TimeZoneByUF::get(UFList::getUFByCode((int)$cUF));
         $dt = new \DateTime(date("Y-m-d H:i:sP"), new \DateTimeZone($tz));
 
         $dt->setTimestamp($contingency->timestamp);

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -650,7 +650,7 @@ class Tools extends ToolsCommon
             self::EVT_DESCONHECIMENTO,
             self::EVT_NAO_REALIZADA,
         ];
-        if (!$std || empty($std->evento)) {
+        if (empty($std->evento)) {
             throw new InvalidArgumentException('Manifestacao: parametro "std" ou evento estao vazios!');
         }
         if (count($std->evento) > 20) {
@@ -731,7 +731,7 @@ class Tools extends ToolsCommon
      */
     public function sefazEventoLote($uf, \stdClass $std)
     {
-        if (empty($uf) || !$std) {
+        if (empty($uf)) {
             throw new InvalidArgumentException('Evento Lote: UF ou parametro "std" vazio!');
         }
         if (count($std->evento) > 20) {


### PR DESCRIPTION
Não é necessário ter o `!$std` uma vez que não tem como passar esse parâmetro como null, pois ele é obrigatório na declaração do método.