### PR TITLE
altera data do evento da Carta de Correção para enviar com o timezone do estado

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -902,6 +902,7 @@ class Tools extends ToolsCommon
         $descEvento = $ev->desc;
         $cnpj = $this->config->cnpj ?? '';
         $dt = new \DateTime(date("Y-m-d H:i:sP"), new \DateTimeZone($this->timezone));
+        $dt->setTimezone(new \DateTimeZone($this->timezone));
         $dhEvento = $dt->format('Y-m-d\TH:i:sP');
         $sSeqEvento = str_pad((string)$nSeqEvento, 2, "0", STR_PAD_LEFT);
         $eventId = "ID" . $tpEvento . $chave . $sSeqEvento;


### PR DESCRIPTION
Altera data do evento no envio da Carta de Correção para usar o timezone do estado, ao invés de mandar como UTC, para ficar igual ao código do envio do lote para a Sefaz, e também para permitir a correção na exibição da data/hora na carta de correção impressa (vou fazer um pull request no projeto sped-da também)