### PR TITLE
Codecov support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - develop
+      - codecov-support
 
   pull_request:
     branches:
@@ -24,6 +25,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, intl, mysql, zlib, dom, openssl, soap, json, simplexml, libxml
+          coverage: pcov
 
       - name: checkout
         uses: actions/checkout@v3
@@ -40,5 +42,15 @@ jobs:
           composer stan
 
       - name: Rodando PHPUnit
+        if: matrix.php-version != '8.2'
         run: |
           composer test
+
+      - name: Rodando PHPUnit
+        if: matrix.php-version == '8.2'
+        run: |
+          composer test-with-coverage
+
+      - name: Submit code coverage
+        if: matrix.php-version == '8.2'
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Biblioteca para geração e comunicação das NFe com as SEFAZ autorizadoras, e 
 ![PHP Supported Version][ico-php]
 ![Actions](https://github.com/nfephp-org/sped-nfe/actions/workflows/ci.yml/badge.svg)
 [![Chat][ico-gitter]][link-gitter]
+[![codecov](https://codecov.io/gh/gersonfs/sped-nfe/branch/codecov-support/graph/badge.svg?token=U0Z87MS0DA)](https://codecov.io/gh/gersonfs/sped-nfe)
 
 [![Latest Stable Version][ico-stable]][link-packagist]
 [![Latest Version on Packagist][ico-version]][link-packagist]

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit -c phpunit.xml.dist",
+        "test-with-coverage": "vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.xml",
         "phpcbf": "vendor/bin/phpcbf src/",
         "phpcs": "vendor/bin/phpcs src/",
         "stan": "vendor/bin/phpstan analyse src/"


### PR DESCRIPTION
Fala Roberto!
Seria bacana a gente adicionar o badge do codecov para mostrar o percentual de cobertura dos testes, pois incentiva o pessoal a contribuir (eu pelo menos, quando vejo o percentual aumentar). Você poderia fazer ali? Veja aqui como fica:
https://github.com/gersonfs/sped-nfe/tree/codecov-support
![image](https://user-images.githubusercontent.com/293154/225349181-16c146da-be14-4665-980d-769c92923b43.png)

