### PR TITLE
Added adRemICMSRet to possible ICMS fields.

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -3009,7 +3009,8 @@ class Make
             'adRemICMSReten',
             'vICMSMonoReten',
             'vICMSMonoDif',
-            'vICMSMonoRet'
+            'vICMSMonoRet',
+            'adRemICMSRet'
         ];
         $std = $this->equilizeParameters($std, $possible);
         $identificador = 'N01 <ICMSxx> - ';


### PR DESCRIPTION
Ajuste relacionado a NT 2023.001 v1.20.

A tag adRemICMSRet é usada no CST 61 mas não tem registro nas tags "possíveis".