### PR TITLE
Atribuir objeto Contingency recebido por parâmetro

### DIFF
--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -189,8 +189,11 @@ class Tools
         $this->certificate = $certificate;
         $this->typePerson = $this->getTypeOfPersonFromCertificate();
         $this->setEnvironment($this->config->tpAmb);
+        
         if (empty($contingency)) {
             $this->contingency = new Contingency();
+        }else{
+            $this->contingency = $contingency;
         }
     }
 


### PR DESCRIPTION
A classe Tools (método `__construct`) não estava atribuindo o objeto da contingência (`Contingency`) quando o mesmo era recebido por parâmetro.