### PR TITLE
Ajuste link consulta NFCe UF PB

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "compufour/sped-nfe",
     "type": "library",
     "description": "API para geração e comunicação da NFe e NFCe com as SEFAZ autorizadoras.",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/compufour/sped-common"
+        }
+    ],
     "keywords": [
         "nfe",
         "nfce",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nfephp-org/sped-nfe",
+    "name": "compufour/sped-nfe",
     "type": "library",
     "description": "API para geração e comunicação da NFe e NFCe com as SEFAZ autorizadoras.",
     "keywords": [
@@ -8,7 +8,7 @@
         "sped",
         "nfephp"
     ],
-    "homepage": "https://github.com/nfephp-org/sped-nfe",
+    "homepage": "https://github.com/compufour/sped-nfe",
     "license": [
         "LGPL-3.0-or-later",
         "GPL-3.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "nfephp-org/sped-common": "^5.1.0",
+        "compufour/sped-common": "^5.1.0",
         "nfephp-org/sped-gtin": "^1.1.0",
         "justinrainbow/json-schema": "^5.2",
         "ext-zlib": "*",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "compufour/sped-common": "^5.1.0",
+        "compufour/sped-common": "dev-master",
         "nfephp-org/sped-gtin": "^1.1.0",
         "justinrainbow/json-schema": "^5.2",
         "ext-zlib": "*",

--- a/storage/uri_consulta_nfce.json
+++ b/storage/uri_consulta_nfce.json
@@ -26,7 +26,7 @@
         "SE": "http:\/\/www.nfce.se.gov.br\/nfce\/consulta",
         "SP": "https:\/\/www.nfce.fazenda.sp.gov.br\/NFCeConsultaPublica",
         "TO": "www.sefaz.to.gov.br\/nfce\/consulta",
-        "PB": "www.receita.pb.gov.br\/nfce\/consulta"
+        "PB": "www.sefaz.pb.gov.br\/nfce\/consulta"
     },
     "2": {
         "AC": "www.sefaznet.ac.gov.br\/nfce\/consulta",
@@ -43,7 +43,7 @@
         "MS": "http:\/\/www.dfe.ms.gov.br\/nfce\/consulta",
         "MT": "http:\/\/homologacao.sefaz.mt.gov.br\/nfce\/consultanfce",
         "PA": "www.sefa.pa.gov.br\/nfce\/consulta",
-        "PB": "www.receita.pb.gov.br\/nfcehom",
+        "PB": "www.sefaz.pb.gov.br\/nfcehom",
         "PE": "nfce.sefaz.pe.gov.br\/nfce\/consulta",
         "PR": "http:\/\/www.fazenda.pr.gov.br\/nfce\/consulta",
         "PI": "www.sefaz.pi.gov.br\/nfce\/consulta",


### PR DESCRIPTION
A URL da página de consulta estadual da NFC-e do estado da Paraíba para inclusão no Código do QR Code foi alterada para a seguinte: http://www.sefaz.pb.gov.br/nfce

A URL anterior (http://www.receita.pb.gov.br/nfce) não deve ser mais utilizada, pois leva para uma página inexistente. Esta
URL antiga não será aceita a partir de 01/04/2024.