### PR TITLE
Inclui tag dPag conforme NT 2023.004

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -7001,6 +7001,7 @@ class Make
             'tPag',
             'xPag',
             'vPag',
+            'dPag',
             'CNPJ',
             'tBand',
             'cAut',
@@ -7040,6 +7041,13 @@ class Make
             $this->conditionalNumberFormatting($std->vPag),
             true,
             "Valor do Pagamento"
+        );
+        $this->dom->addChild(
+            $detPag,
+            "dPag",
+            !empty($std->dPag) ? $std->dPag : null,
+            false,
+            "Data do Pagamento"
         );
         //NT 2023.004 v1.00
         if (!empty($std->CNPJPag) && !empty($std->UFPag)) {


### PR DESCRIPTION
De acordo com a NT 2023.004, no grupo "YA. Informações de pagamento", foi incluído a tag dPag (campo de ID YA03a).

Atualmente na branch master do sped-nfe já contém as outras tags, apenas a dPag que não.

![image](https://github.com/nfephp-org/sped-nfe/assets/69996639/394dae47-33ca-47c6-b9e6-127ed0b45dcc)

Segue abaixo a NT 2023.004 e suas respectivas atualizações:
[NT2023_004 v1.00 - ECONF - Campos - e Regras.pdf](https://github.com/nfephp-org/sped-nfe/files/14654998/NT2023_004.v1.00.-.ECONF.-.Campos.-.e.Regras.pdf)
[NT2023.004_v1.10 -Campos e Regras (1).pdf](https://github.com/nfephp-org/sped-nfe/files/14655000/NT2023.004_v1.10.-Campos.e.Regras.1.pdf)
[NT2023.004_v1.11 -Campos e Regras.pdf](https://github.com/nfephp-org/sped-nfe/files/14654997/NT2023.004_v1.11.-Campos.e.Regras.pdf)