### PR TITLE
fix: indIEDest String Value

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1229,7 +1229,7 @@ class Make
             $std->indIEDest = 2;
         }
         if ($this->mod == '65') {
-            $std->indIEDest = 9;
+            $std->indIEDest = '9';
             if (empty($std->xNome)) {
                 $flagNome = false; //marca se xNome é ou não obrigatório
             }


### PR DESCRIPTION
Se informado indIEDest como inteiro, nao irá passar na formatação `\NFePHP\Common\Strings::onlyNumbers($std->indIEDest)`, que retorna string vazia.