### PR TITLE
Correção na verificação do preenchimento da chave de acesso da NF-e referenciada

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -799,7 +799,7 @@ class Make
     {
         $possible = ['refNFe', 'refNFeSig'];
         $std = $this->equilizeParameters($std, $possible);
-        if (empty($std->refNFe) && empty($std->refNFe)) {
+        if (empty($std->refNFe) && empty($std->refNFeSig)) {
             return $this->dom->createElement("refNFe", '');
         }
         $num = $this->buildNFref();


### PR DESCRIPTION
No ponto abaixo, é verificado duas vezes se 'refNFe' é vazio. Se 'refNFe' for vazio e  'refNFeSig' for preenchido, a execução irá parar no _return_ da linha 803 e o elemento 'refNFeSig' não será criado.

![Captura de tela 2025-04-25 102851](https://github.com/user-attachments/assets/e1460029-5d2d-4a1b-b385-a91db7dc9e33)

Sendo assim, alterei para que seja verificado se ambos são vazios. Realizei testes de transmissão para essas situações.