### PR TITLE
Ajuste para só tentar gerar tag enderDest caso informada

### DIFF
--- a/src/MakeDev.php
+++ b/src/MakeDev.php
@@ -1252,7 +1252,9 @@ final class MakeDev
             if (!isset($node)) {
                 $node = $this->dest->getElementsByTagName("IE")->item(0);
             }
-            $this->dest->insertBefore($this->enderDest, $node);
+            if (!is_null($this->enderDest)) {
+                $this->dest->insertBefore($this->enderDest, $node);
+            }
         }
         $this->dom->appChild($this->infNFe, $this->dest);
     }


### PR DESCRIPTION
Caso a tag não fosse informada ocorria o erro "must be of type DOMNode, null given". No caso de uma NFC-e, ela pode ter só o CPF, sem a necessidade do endereço, por exemplo.