### PR TITLE
Correção calculo vNFTot

### DIFF
--- a/src/MakeDev.php
+++ b/src/MakeDev.php
@@ -1587,7 +1587,7 @@ final class MakeDev
             if (!empty($this->IBSCBSTot)) {
                 $this->addTag($total, $this->IBSCBSTot);
                 //campo vNFTot PL_010
-                $vNFTot = $this->stdTot->vNF; //+ $this->stdTot->vIBS + $this->stdTot->vCBS + $this->stdTot->vIS;
+                $vNFTot = $this->stdTot->vNF + $this->stdTot->vIBS + $this->stdTot->vCBS + $this->stdTot->vIS;
                 $this->dom->addChild(
                     $total,
                     "vNFTot",


### PR DESCRIPTION
O campo novo foi criado e é diferente do total da NF-e atual (vNF). Cálculo já estava certo conforme a NT, só foi descomentado o somatório do CBS e IBS ao total da NF-e