### PR TITLE
Correção do nome do campo pIPI

### DIFF
--- a/src/Traits/TraitTagDetIPI.php
+++ b/src/Traits/TraitTagDetIPI.php
@@ -81,7 +81,7 @@ trait TraitTagDetIPI
                 true,
                 "$identificador Código da situação tributária do IPI (CST)"
             );
-            if (!empty($std->vBC) && !empty($std->pIIPI)) {
+            if (!empty($std->vBC) && !empty($std->pIPI)) {
                 $this->dom->addChild(
                     $ipiTrib,
                     "vBC",


### PR DESCRIPTION
Corrigido o nome do campo. Estava causando falha de schema pois nunca encontrava o valor correto do pIPI e acabava criando a tag de IPI de maneira incorreta.