### PR TITLE
Update TraitTagAgropecuario.php

### DIFF
--- a/src/Traits/TraitTagAgropecuario.php
+++ b/src/Traits/TraitTagAgropecuario.php
@@ -28,6 +28,7 @@ trait TraitTagAgropecuario
         $possible = [
             'tpGuia',
             'UFGuia',
+            'serieGuia',
             'nGuia'
         ];
         $std = $this->equilizeParameters($std, $possible);
@@ -46,6 +47,13 @@ trait TraitTagAgropecuario
             !empty($std->UFGuia) ? $std->UFGuia : null,
             false,
             "UF de emissão"
+        );
+        $this->dom->addChild(
+            $guia,
+            "serieGuia",
+            !empty($std->serieGuia) ? $std->serieGuia : null,
+            false,
+            "Série da Guia"
         );
         $this->dom->addChild(
             $guia,


### PR DESCRIPTION
Restauração do campo de série da guia de trânsito. Não encontrei atualização de NT removendo o campo e nos schemas liberados 010b (liberado em 30/07/2025) ainda constava o campo. 

Se realmente foi removido, por favor informar onde está a alteração para eu me adequar também.