### PR TITLE
Correção da extração da chave pelo ID

### DIFF
--- a/src/Traits/TraitTagInfNfe.php
+++ b/src/Traits/TraitTagInfNfe.php
@@ -28,7 +28,7 @@ trait TraitTagInfNfe
         $chave = null;
         $this->version = (string) $std->versao;
         if (!empty($std->Id)) {
-            $chave = substr($std->Id, 2, 44);
+            $chave = preg_replace('/[^0-9]/', '', (string)$std->Id);
         }
         $this->infNFe = $this->dom->createElement("infNFe");
         $this->infNFe->setAttribute("Id", 'NFe' . $chave);


### PR DESCRIPTION
A chave estava sendo copiada da posição errada do ID. Em casos de ID "NFe12345678901234567890123456789012345678901234" estava pegando "e1234567890123456789012345678901234567890123", pela posição incorreta do substr. Alterei para o preg_replace, a mesma função usada pelo make.php.