### PR TITLE
Correção no total monofásico

### DIFF
--- a/src/Traits/TraitTagDetIBSCBS.php
+++ b/src/Traits/TraitTagDetIBSCBS.php
@@ -638,12 +638,12 @@ trait TraitTagDetIBSCBS
         ];
         $std = $this->equilizeParameters($std, $possible);
         //Totalizador
-        $this->stdIBSCBSTot->gIBSCBSMono->vIBSMono += $std->vIBSMono ?? 0;
-        $this->stdIBSCBSTot->gIBSCBSMono->vCBSMono += $std->vCBSMono ?? 0;
-        $this->stdIBSCBSTot->gIBSCBSMono->vIBSMonoReten += $std->vIBSMonoReten ?? 0;
-        $this->stdIBSCBSTot->gIBSCBSMono->vCBSMonoReten += $std->vCBSMonoReten ?? 0;
-        $this->stdIBSCBSTot->gIBSCBSMono->vIBSMonoRet += $std->vIBSMonoRet ?? 0;
-        $this->stdIBSCBSTot->gIBSCBSMono->vCBSMonoRet += $std->vCBSMonoRet ?? 0;
+        $this->stdIBSCBSTot->gMono->vIBSMono += $std->vIBSMono ?? 0;
+        $this->stdIBSCBSTot->gMono->vCBSMono += $std->vCBSMono ?? 0;
+        $this->stdIBSCBSTot->gMono->vIBSMonoReten += $std->vIBSMonoReten ?? 0;
+        $this->stdIBSCBSTot->gMono->vCBSMonoReten += $std->vCBSMonoReten ?? 0;
+        $this->stdIBSCBSTot->gMono->vIBSMonoRet += $std->vIBSMonoRet ?? 0;
+        $this->stdIBSCBSTot->gMono->vCBSMonoRet += $std->vCBSMonoRet ?? 0;
 
         $identificador = "UB84 <gIBSCBSMono> -";
         $gIBSCBSMono = $this->dom->createElement("gIBSCBSMono");


### PR DESCRIPTION
A totalização monofásica está sendo salva em objeto inexistente - _gIBSCBSMono_. O correto, conforme abaixo, é _gMono_.
![make](https://github.com/user-attachments/assets/e38a6913-e54f-448b-91c3-f3326bc22f95)
![trait](https://github.com/user-attachments/assets/63abde89-b4da-421b-a0bf-dd395ffeedc7)
