### PR TITLE
Correção das tags do grupo gTribCompraGov

### DIFF
--- a/src/Traits/TraitTagDetIBSCBS.php
+++ b/src/Traits/TraitTagDetIBSCBS.php
@@ -559,44 +559,44 @@ trait TraitTagDetIBSCBS
         $this->dom->addChild(
             $gTrib,
             "pAliqIBSUF",
-            $this->conditionalNumberFormatting($std->pIBSUF, 4),
+            $this->conditionalNumberFormatting($std->pAliqIBSUF, 4),
             true,
-            "$identificador Alíquota do IBS de competência do Estado. (pIBSUF)"
+            "$identificador Alíquota do IBS de competência do Estado. (pAliqIBSUF)"
         );
         $this->dom->addChild(
             $gTrib,
-            "vIBSUF",
-            $this->conditionalNumberFormatting($std->pIBSUF),
+            "vTribIBSUF",
+            $this->conditionalNumberFormatting($std->vTribIBSUF),
             true,
-            "$identificador Valor do Tributo do IBS da UF calculado. (vIBSUF)"
+            "$identificador Valor do Tributo do IBS da UF calculado. (vTribIBSUF)"
         );
         $this->dom->addChild(
             $gTrib,
-            "pIBSMun",
-            $this->conditionalNumberFormatting($std->pIBSMun, 4),
+            "pAliqIBSMun",
+            $this->conditionalNumberFormatting($std->pAliqIBSMun, 4),
             true,
-            "$identificador Alíquota do IBS de competência do Município. (pIBSMun)"
+            "$identificador Alíquota do IBS de competência do Município. (pAliqIBSMun)"
         );
         $this->dom->addChild(
             $gTrib,
-            "vIBSMun",
-            $this->conditionalNumberFormatting($std->vIBSMun),
+            "vTribIBSMun",
+            $this->conditionalNumberFormatting($std->vTribIBSMun),
             true,
-            "$identificador Valor do Tributo do IBS do Município calculado. (vIBSMun)"
+            "$identificador Valor do Tributo do IBS do Município calculado. (vTribIBSMun)"
         );
         $this->dom->addChild(
             $gTrib,
-            "pCBS",
-            $this->conditionalNumberFormatting($std->pCBS, 4),
+            "pAliqCBS",
+            $this->conditionalNumberFormatting($std->pAliqCBS, 4),
             true,
-            "$identificador Alíquota da CBS. (pCBS)"
+            "$identificador Alíquota da CBS. (pAliqCBS)"
         );
         $this->dom->addChild(
             $gTrib,
-            "vCBS",
-            $this->conditionalNumberFormatting($std->vCBS),
+            "vTribCBS",
+            $this->conditionalNumberFormatting($std->vTribCBS),
             true,
-            "$identificador Valor do Tributo da CBS calculado. (vCBS)"
+            "$identificador Valor do Tributo da CBS calculado. (vTribCBS)"
         );
         $this->aGTribCompraGov[$std->item] = $gTrib;
         return $gTrib;


### PR DESCRIPTION
Conforme abaixo, as _tags_ estão incorretas.
![compra-gov-1](https://github.com/user-attachments/assets/5823700c-d48f-4b70-b1e6-eaaf40635dca)
![compra-gov-2](https://github.com/user-attachments/assets/5976b762-6b49-4b1a-aaa3-2f7bac537770)
