### PR TITLE
Validação na tag vCredPresIBSZFM para inseri-la apenas quando informada

### DIFF
--- a/src/Traits/TraitTagDetIBSCBS.php
+++ b/src/Traits/TraitTagDetIBSCBS.php
@@ -886,14 +886,16 @@ trait TraitTagDetIBSCBS
             "$identificador Tipo de classificação de acordo com o art. 450, paragrafo 1, da LC 214/25 para o "
                 . "cálculo do crédito presumido na ZFM (tpCredPresIBSZFM)"
         );
-        $this->dom->addChild(
-            $cred,
-            "vCredPresIBSZFM",
-            $std->vCredPresIBSZFM,
-            true,
-            "$identificador Valor do crédito presumido calculado sobre o saldo devedor "
-                . "apurado (vCredPresIBSZFM)"
-        );
+        if (!empty($std->vCredPresIBSZFM)) {
+            $this->dom->addChild(
+                $cred,
+                "vCredPresIBSZFM",
+                $std->vCredPresIBSZFM,
+                true,
+                "$identificador Valor do crédito presumido calculado sobre o saldo devedor "
+                    . "apurado (vCredPresIBSZFM)"
+            );
+        }
         $this->aGCredPresIBSZFM[$std->item] = $cred;
         return $cred;
     }


### PR DESCRIPTION
Inserção da tag vCredPresIBSZFM apenas quando informada. A mesma é obrigatória apenas se é nota de crédito com tpNFCredito = 02 conforme anexo.

<img width="1141" height="164" alt="image" src="https://github.com/user-attachments/assets/d3f4bdf7-fed3-4cee-87cc-bf09295344e5" />

