### PR TITLE
Correções no arquivo Make para nova TAG "agropecuario"

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -7791,10 +7791,8 @@ class Make
             "CPF do Responsável Técnico, emitente do receituário"
         );
         $this->aDefencivo[] = $def;
-        $agro = $this->dom->createElement("agropecuario");
-        $agro->appendChild($def);
         $this->flagAgro = true;
-        return $agro;
+        return $def;
     }
 
     /**
@@ -7843,10 +7841,8 @@ class Make
             "Número da Guia"
         );
         $this->agropecuarioGuia = $guia;
-        $agro = $this->dom->createElement("agropecuario");
-        $agro->appendChild($guia);
         $this->flagAgro = true;
-        return $agro;
+        return $guia;
     }
 
     /**

--- a/tests/MakeTest.php
+++ b/tests/MakeTest.php
@@ -1090,7 +1090,7 @@ class MakeTest extends TestCase
         //$std->nGuia = '123456789'; //Obrigatório se houver guia 9 digitos, opcional caso contrario
 
         $element = $this->make->tagAgropecuarioDefensivo($std);
-        $this->validarCriacaoTag2($std, $element, 'agropecuario', ['nReceituario', 'CPFRespTec']);
+        $this->validarCriacaoTag2($std, $element, 'defensivo', ['nReceituario', 'CPFRespTec']);
     }
 
     public function test_tagagropecuario_guia(): void
@@ -1104,7 +1104,7 @@ class MakeTest extends TestCase
         $std->nGuia = '123456789'; //Obrigatório se houver guia 9 digitos, opcional caso contrario
 
         $element = $this->make->tagAgropecuarioGuia($std);
-        $this->validarCriacaoTag2($std, $element, 'agropecuario', ['tpGuia']);
+        $this->validarCriacaoTag2($std, $element, 'guiaTransito', ['tpGuia']);
     }
 
     private function validarCriacaoTag2(


### PR DESCRIPTION
Quando estava tentando emtir NF-e passando os novos campos da tag _agropecuario_ estava tendo o seguinte erro:
Couldn't fetch DOMElement

analisando o código da classe Make, vi que a tag _agropecuario_ era criada nas funções tagAgropecuarioGuia(), tagAgropecuarioDefensivo() e também na monta(). 

Removi a chamada de createElement("agropecuario") nas funções tagAgropecuarioGuia() e tagAgropecuarioDefensivo(), mantendo somente na monta(), assim parou de retornar o erro, acredito que seja por que as tags "filhos" de _agropecuario_ eram perdidas quando a tag "pai" _agropecuario_ era criada novamente.