### PR TITLE
Ajuste no Make.php e na TraitEventsRTC.php

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -2112,23 +2112,53 @@ class Make
         ];
         $std = $this->equilizeParameters($std, $possible);
         $identificador = 'VA01 <obsItem> - ';
-        $obsItem = $this->dom->createElement("obsItem");
+        if (isset($this->obsItem[$std->item])) {
+            $obsItem = $this->obsItem[$std->item];
+        } else {
+            $obsItem = $this->dom->createElement("obsItem");
+        }
         $obsCont = $this->dom->createElement("obsCont");
-        $this->dom->addChild(
-            $obsCont,
-            "xCampo",
-            substr(trim($std->xCampo ?? ''), 0, 20),
-            true,
-            $identificador . "[item $std->item] (obsCont/xCampo) Identificação do campo"
-        );
+        $obsCont->setAttribute("xCampo", $std->xCampo);
         $this->dom->addChild(
             $obsCont,
             "xTexto",
-            substr(trim($std->xTexto ?? ''), 0, 60),
+            $std->xTexto,
             true,
             $identificador . "[item $std->item] (obsCont/xTexto) Conteúdo do campo"
         );
         $obsItem->appendChild($obsCont);
+        $this->obsItem[$std->item] = $obsItem;
+        return $obsItem;
+    }
+
+    /**
+     * Grupo de observações de uso livre (para o item da NF-e)
+     * Grupo de observações de uso livre do Fisco
+     */
+    public function tagprodObsFisco(stdClass $std): ?DOMElement
+    {
+        $possible = [
+            'item',
+            'xCampo',
+            'xTexto'
+        ];
+        $std = $this->equilizeParameters($std, $possible);
+        $identificador = 'VA01 <obsItem> - ';
+        if (isset($this->obsItem[$std->item])) {
+            $obsItem = $this->obsItem[$std->item];
+        } else {
+            $obsItem = $this->dom->createElement("obsItem");
+        }
+        $obsFisco = $this->dom->createElement("obsFisco");
+        $obsFisco->setAttribute("xCampo", $std->xCampo);
+        $this->dom->addChild(
+            $obsFisco,
+            "xTexto",
+            $std->xTexto,
+            true,
+            $identificador . "[item $std->item] (obsFisco/xTexto) Conteúdo do campo"
+        );
+        $obsItem->appendChild($obsFisco);
         $this->obsItem[$std->item] = $obsItem;
         return $obsItem;
     }

--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -95,7 +95,7 @@ trait TraitEventsRTC
         $gcred = '';
         foreach ($std->itens as $item) {
             $bc = number_format($item->vBC, 2, '.', '');
-            $gcred = "<gCredPres><nItem>{$item->item}</nItem><vBC>{$bc}</vBC>";
+            $gcred .= "<gCredPres><nItem>{$item->item}</nItem><vBC>{$bc}</vBC>";
             if (!empty($item->gIBS)) {
                 $g = $item->gIBS;
                 $pc = number_format($g->pCredPres, 4, '.', '');

--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -95,7 +95,7 @@ trait TraitEventsRTC
         $gcred = '';
         foreach ($std->itens as $item) {
             $bc = number_format($item->vBC, 2, '.', '');
-            $gcred .= "<gCredPres><nItem>{$item->item}</nItem><vBC>{$bc}</vBC>";
+            $gcred .= "<gCredPres nItem=\"{$item->item}\"><vBC>{$bc}</vBC>";
             if (!empty($item->gIBS)) {
                 $g = $item->gIBS;
                 $pc = number_format($g->pCredPres, 4, '.', '');

--- a/tests/MakeTest.php
+++ b/tests/MakeTest.php
@@ -457,7 +457,21 @@ class MakeTest extends TestCase
         $tag = $this->make->tagprodObsCont($std);
 
         $this->assertEquals('obsItem', $tag->nodeName);
-        $this->assertEquals($std->xCampo, $tag->getElementsByTagName('xCampo')->item(0)->nodeValue);
+        $this->assertEquals($std->xCampo, $tag->getElementsByTagName('obsCont')->item(0)->getAttribute('xCampo'));
+        $this->assertEquals($std->xTexto, $tag->getElementsByTagName('xTexto')->item(0)->nodeValue);
+    }
+
+    public function test_tagprodObsFisco(): void
+    {
+        $std = new \stdClass();
+        $std->item = 1;
+        $std->xCampo = 'abc';
+        $std->xTexto = '123';
+
+        $tag = $this->make->tagprodObsFisco($std);
+
+        $this->assertEquals('obsItem', $tag->nodeName);
+        $this->assertEquals($std->xCampo, $tag->getElementsByTagName('obsFisco')->item(0)->getAttribute('xCampo'));
         $this->assertEquals($std->xTexto, $tag->getElementsByTagName('xTexto')->item(0)->nodeValue);
     }
 


### PR DESCRIPTION
# Ajustes Realizados

## src/Make.php 

tagprodObsCont: Ajustada para respeitar o xCampo como atributo e modificado a lógica para a utilização não ordenada da função tagprodObsFisco.

tagprodObsFisco: Foi implementado seguindo o mesmo padrão da função tagprodObsCont. 

Referencia utilizada para os ajustes: [NT 2021.004 versão 1.33 - Portal da Nota Fiscal Eletrônica](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=No7WPPlEEeg=)

## src/Traits/TraitEventsRTC.php

sefazSolApropCredPresumido: 
- Foi modificado para aceitar a concatenação do gcred por item em cada iteração no for. 
- Ajusta o nItem para ser um atributo do gCredPres como sugere a Norma Técnica ([Reforma Tributária do Consumo – Adequações NF-e / NFC-e](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=YFz9is%20R6tw=))



