### PR TITLE
ajusta a função sefazDestinoConsumoPessoal

### DIFF
--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -174,8 +174,7 @@ trait TraitEventsRTC
             $vi = number_format($item->vIBS, 2, '.', '');
             $vc = number_format($item->vCBS, 2, '.', '');
             $qt = number_format($item->quantidade, 4, '.', '');
-            $gc = "<gConsumo>"
-                . "<nItem>{$item->item}</nItem>"
+            $gc = "<gConsumo nItem=\"{$item->item}\">"
                 . "<vIBS>{$vi}</vIBS>"
                 . "<vCBS>{$vc}</vCBS>"
                 . "<gControleEstoque>"
@@ -184,7 +183,7 @@ trait TraitEventsRTC
                 . "</gControleEstoque>"
                 . "<DFeReferenciado>"
                 . "<chaveAcesso>{$item->chave}</chaveAcesso>"
-                . "<nItem>{$item->nItem}</nItem>"
+                . "<nItemDFeRef>{$item->nItem}</nItemDFeRef>"
                 . "</DFeReferenciado>"
                 . "</gConsumo>";
             $tagAdic .= $gc;


### PR DESCRIPTION
# Ajuste

## TraitEventsRTC.php

Função: sefazDestinoConsumoPessoal
- ajusta o nItem de elemento para atributo
- ajusta o nome do elemento DFeReferenciado/nItem para nItemDFeRef

Referência: [Reforma Tributária do Consumo – Adequações NF-e / NFC-e](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=YFz9is%20R6tw=)