### PR TITLE
ajusta a função sefazImobilizacaoItem

### DIFF
--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -276,13 +276,12 @@ trait TraitEventsRTC
             $vi = number_format($item->vIBS, 2, '.', '');
             $vc = number_format($item->vCBS, 2, '.', '');
             $qtd = number_format($item->quantidade, 4, '.', '');
-            $gc = "<gImobilizacao>"
-                . "<nItem>{$item->item}</nItem>"
+            $gc = "<gImobilizacao nItem=\"{$item->item}\">"
                 . "<vIBS>{$vi}</vIBS>"
                 . "<vCBS>{$vc}</vCBS>"
                 . "<gControleEstoque>"
-                . "<qConsumo>{$qtd}</qConsumo>"
-                . "<uConsumo>{$item->unidade}</uConsumo>"
+                . "<qImobilizado>{$qtd}</qImobilizado>"
+                . "<uImobilizado>{$item->unidade}</uImobilizado>"
                 . "</gControleEstoque>"
                 . "</gImobilizacao>";
             $tagAdic .= $gc;


### PR DESCRIPTION

# Ajuste

## TraitEventsRTC.php

Função: sefazImobilizacaoItem
- ajusta o nItem de elemento para atributo
- correção das tags qImobilizado e uImobilizado

Referência: [Reforma Tributária do Consumo – Adequações NF-e / NFC-e](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=YFz9is%20R6tw=)