### PR TITLE
ajusta a função sefazApropriacaoCreditoComb

### DIFF
--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -339,13 +339,12 @@ trait TraitEventsRTC
             $vi = number_format($item->vIBS, 2, '.', '');
             $vc = number_format($item->vCBS, 2, '.', '');
             $qtd = number_format($item->quantidade, 4, '.', '');
-            $gc = "<gConsumoComb>"
-                . "<nItem>{$item->item}</nItem>"
+            $gc = "<gConsumoComb nItem=\"{$item->item}\">"
                 . "<vIBS>{$vi}</vIBS>"
                 . "<vCBS>{$vc}</vCBS>"
                 . "<gControleEstoque>"
-                . "<qConsumo>{$qtd}</qConsumo>"
-                . "<uConsumo>{$item->unidade}</uConsumo>"
+                . "<qComb>{$qtd}</qComb>"
+                . "<uComb>{$item->unidade}</uComb>"
                 . "</gControleEstoque>"
                 . "</gConsumoComb>";
             $tagAdic .= $gc;


### PR DESCRIPTION
# Ajuste

## TraitEventsRTC.php

Função: sefazApropriacaoCreditoComb
- ajusta o nItem de elemento para atributo
- correção das tags qComb e uComb

Referência: [Reforma Tributária do Consumo – Adequações NF-e / NFC-e](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=YFz9is%20R6tw=)
