### PR TITLE
ajusta a função sefazApropriacaoCreditoBens

### DIFF
--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -389,12 +389,11 @@ trait TraitEventsRTC
             . "<tpAutor>2</tpAutor>"  //2=Empresa destinatária.
             . "<verAplic>{$verAplic}</verAplic>";
         foreach ($std->itens as $item) {
-            $vi = number_format($item->vIBS, 2, '.', '');
-            $vc = number_format($item->vCBS, 2, '.', '');
-            $cred = "<gCredito>"
-                . "<nItem>{$item->item}</nItem>"
-                . "<vIBS>{$vi}</vIBS>"
-                . "<vCBS>{$vc}</vCBS>"
+            $vi = number_format($item->vCredIBS, 2, '.', '');
+            $vc = number_format($item->vCredCBS, 2, '.', '');
+            $cred = "<gCredito nItem=\"{$item->item}\">"
+                . "<vCredIBS>{$vi}</vCredIBS>"
+                . "<vCredCBS>{$vc}</vCredCBS>"
                 . "</gCredito>";
             $tagAdic .= $cred;
         }


### PR DESCRIPTION
# Ajuste

## TraitEventsRTC.php

Função: sefazApropriacaoCreditoBens
- ajusta o nome das propriedades vCredIBS e vCredCBS
- ajusta o nItem de elemento para atributo
- correção das tags vCredIBS e vCredCBS

Referência: [Reforma Tributária do Consumo – Adequações NF-e / NFC-e](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=YFz9is%20R6tw=)
