### PR TITLE
Corrige descrição do Evento 212110

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -1524,7 +1524,7 @@ class Tools extends ToolsCommon
                 break;
             case 212110:
                 $std->alias = 'envEvento';
-                $std->desc = 'Manifestação sobre Pedido de Transferência de Crédito de IBS em Operações de Sucessão';
+                $std->desc = 'Manifestação sobre Pedido de Transferência de Crédito de IBS em Operação de Sucessão';
                 break;
             case 212120:
                 $std->alias = 'envEvento';


### PR DESCRIPTION
# Ajuste

## Tools.php

Função: tpEv
- corrige descrição da manifestação sobre pedido de transferência de crédito de IBS

Referência: schemes/PL_010_V1/e212110_v1.00.xsd

