### PR TITLE
ajusta a função sefazRouboPerdaTransporteFornecedor

### DIFF
--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -633,14 +633,17 @@ trait TraitEventsRTC
         foreach ($std->itens as $item) {
             $vi = number_format($item->vIBS, 2, '.', '');
             $vc = number_format($item->vCBS, 2, '.', '');
+            $gvi = number_format($item->gControleEstoque_vIBS, 2, '.', '');
+            $gvc = number_format($item->gControleEstoque_vCBS, 2, '.', '');
             $qtd = number_format($item->quantidade, 4, '.', '');
-            $gc = "<gPerecimento>"
-                . "<nItem>{$item->item}</nItem>"
+            $gc = "<gPerecimento nItem=\"{$item->item}\">"
                 . "<vIBS>{$vi}</vIBS>"
                 . "<vCBS>{$vc}</vCBS>"
                 . "<gControleEstoque>"
                 . "<qPerecimento>{$qtd}</qPerecimento>"
                 . "<uPerecimento>{$item->unidade}</uPerecimento>"
+                . "<vIBS>{$gvi}</vIBS>"
+                . "<vCBS>{$gvc}</vCBS>"
                 . "</gControleEstoque>"
                 . "</gPerecimento>";
             $tagAdic .= $gc;


### PR DESCRIPTION
# Ajuste

## TraitEventsRTC.php

Função: sefazRouboPerdaTransporteFornecedor
- ajusta o nItem de elemento para atributo
- adiciona a tag gControleEstoque/vIBS
- adiciona a tag gControleEstoque/vCBS

Referência: [Reforma Tributária do Consumo – Adequações NF-e / NFC-e](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=YFz9is%20R6tw=)
