### PR TITLE
ajusta a função sefazFornecimentoNaoRealizado

### DIFF
--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -681,8 +681,7 @@ trait TraitEventsRTC
             $vi = number_format($item->vIBS, 2, '.', '');
             $vc = number_format($item->vCBS, 2, '.', '');
             $qtd = number_format($item->quantidade, 4, '.', '');
-            $gc = "<gItemNaoFornecido>"
-                . "<nItem>{$item->item}</nItem>"
+            $gc = "<gItemNaoFornecido nItem=\"{$item->item}\">"
                 . "<vIBS>{$vi}</vIBS>"
                 . "<vCBS>{$vc}</vCBS>"
                 . "<gControleEstoque>"


### PR DESCRIPTION
# Ajuste

## TraitEventsRTC.php

Função: sefazFornecimentoNaoRealizado
- ajusta o nItem de elemento para atributo

Referência: [Reforma Tributária do Consumo – Adequações NF-e / NFC-e](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=YFz9is%20R6tw=)