### PR TITLE
Remove validação incorreta do protNFe durante o processamento da resposta

### DIFF
--- a/src/Complements.php
+++ b/src/Complements.php
@@ -237,15 +237,8 @@ class Complements
         $ret->preserveWhiteSpace = false;
         $ret->formatOutput = false;
         $ret->loadXML($response);
-        $prottpAmb = $ret->getElementsByTagName('tpAmb')->item(0)->nodeValue;
-        $verAplic = $ret->getElementsByTagName('verAplic')->item(0)->nodeValue;
-        $chNFe = $ret->getElementsByTagName('chNFe')->item(0)->nodeValue;
-        $dhRecbto = $ret->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
         $cStat = $ret->getElementsByTagName('cStat')->item(0)->nodeValue;
         $xMotivo = $ret->getElementsByTagName('xMotivo')->item(0)->nodeValue;
-        if ($chNFe !== $chave) {
-            throw DocumentsException::wrongDocument(5, 'A chave da NFe não é igual a chave do protocolo');
-        }
         //retorno pode vir sem o protNFe
         $retProt = $ret->getElementsByTagName('protNFe')->length > 0 ? $ret->getElementsByTagName('protNFe') : null;
         $digProt = null;


### PR DESCRIPTION
Este PR remove uma validação incorreta que era aplicada ao bloco protNFe no processamento da resposta de autorização.

A função que adiciona o protocolo à NFe (addNFeProtocol) realizava uma validação prematura e incorreta: ela pegava o primeiro <chNFe> do XML de resposta e comparava com a chave da nota em processamento. Se esses valores não coincidissem, a função lançava erro imediatamente, mesmo que o protocolo correto estivesse presente em outro <protNFe> do mesmo lote.

Erro que estava sendo lançado:
`Os documentos se referem a diferentes objetos. A chave da NFe não é igual a chave do protocolo.`

Isso causava falhas ao autorizar notas em lotes onde o protocolo da nota alvo não é o primeiro protocolo retornado pela SEFAZ.

Exemplo:
```xml
<retConsReciNFe ...>
  ...
  <protNFe> ... <chNFe>3125...73931813674000</chNFe> ... </protNFe> <!-- 1º -->
  <protNFe> ... <chNFe>3125...74151601727427</chNFe> ... </protNFe> <!-- 2º -->
  <protNFe> ... <chNFe>3125...74161716581953</chNFe> ... </protNFe> <!-- 3º - protocolo correto para a nota -->
  ...
</retConsReciNFe>
```

A lógica removida era desnecessária porque a validação do protocolo correspondente à chave da NFe já ocorre corretamente em múltiplos pontos da biblioteca.

Trechos em que já é feito as validações corretas:

https://github.com/nfephp-org/sped-nfe/blob/5236785738fb51c3a4c50b33c8c22ab0bb5399f8/src/Complements.php#L268-L271

https://github.com/nfephp-org/sped-nfe/blob/5236785738fb51c3a4c50b33c8c22ab0bb5399f8/src/Complements.php#L281-L286
