### PR TITLE
Ajuste gMono no totalizador

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "nuxt.isNuxtApp": false
+}

--- a/src/Traits/TraitTagTotal.php
+++ b/src/Traits/TraitTagTotal.php
@@ -740,7 +740,9 @@ trait TraitTagTotal
             );
             $ibstot->appendChild($gCBS);
         }
-        if (isset($gMono_vIBSMono)) {
+        if (!empty($gMono_vIBSMono) || !empty($gMono_vCBSMono) ||
+            !empty($gMono_vIBSMonoReten) || !empty($gMono_vCBSMonoReten) ||
+            !empty($gMono_vIBSMonoRet) || !empty($gMono_vCBSMonoRet)) {
             $gMono = $this->dom->createElement('gMono');
             $this->dom->addChild(
                 $gMono,


### PR DESCRIPTION
A tag gMono estava saindo em todos os totalizadores, mesmo sem ter Grupo Monofásico