### PR TITLE
Ajuste no preenchimento da tag indAceitacao

### DIFF
--- a/src/Traits/TraitEventsRTC.php
+++ b/src/Traits/TraitEventsRTC.php
@@ -207,6 +207,7 @@ trait TraitEventsRTC
      *
      * $std = new stdClass;
      * $std->chNFe = '12345678901234567890123456789012345678901234';
+     * $std->indAceitacao = 1;
      * $std->nSeqEvento = 1;
      * $std->dhEvento = '2025-09-23\T13:34:30-03:00';
      * $std->lote = null;
@@ -224,7 +225,7 @@ trait TraitEventsRTC
         $tagAdic = "<cOrgaoAutor>{$this->cUF}</cOrgaoAutor>"
             . "<tpAutor>2</tpAutor>" //2=Empresa destinatária
             . "<verAplic>{$verAplic}</verAplic>"
-            . "<indAceitacao>1</indAceitacao>";
+            . "<indAceitacao>{$std->indAceitacao}</indAceitacao>";
         return $this->sefazEvento(
             'SVRS',
             $std->chNFe,
@@ -416,6 +417,7 @@ trait TraitEventsRTC
      *
      *   $std = new stdClass;
      *   $std->chNFe = '12345678901234567890123456789012345678901234';
+     * * $std->indAceitacao = 1;
      *   $std->nSeqEvento = 1;
      *   $std->dhEvento = '2025-09-23\T13:34:30-03:00';
      *   $std->lote = null;
@@ -434,7 +436,7 @@ trait TraitEventsRTC
         $tagAdic = "<cOrgaoAutor>{$this->cUF}</cOrgaoAutor>"
             . "<tpAutor>8</tpAutor>" //8= Empresa sucessora
             . "<verAplic>{$verAplic}</verAplic>"
-            . "<indAceitacao>1</indAceitacao>";
+            . "<indAceitacao>{$std->indAceitacao}</indAceitacao>";
         return $this->sefazEvento(
             'SVRS',
             $std->chNFe,
@@ -454,6 +456,7 @@ trait TraitEventsRTC
      *
      *   $std = new stdClass;
      *   $std->chNFe = '12345678901234567890123456789012345678901234';
+     * * $std->indAceitacao = 1;
      *   $std->nSeqEvento = 1;
      *   $std->dhEvento = '2025-09-23\T13:34:30-03:00';
      *   $std->lote = null;
@@ -472,7 +475,7 @@ trait TraitEventsRTC
         $tagAdic = "<cOrgaoAutor>{$this->cUF}</cOrgaoAutor>"
             . "<tpAutor>8</tpAutor>" //8= Empresa sucessora
             . "<verAplic>{$verAplic}</verAplic>"
-            . "<indAceitacao>1</indAceitacao>";
+            . "<indAceitacao>{$std->indAceitacao}</indAceitacao>";
         return $this->sefazEvento(
             'SVRS',
             $std->chNFe,


### PR DESCRIPTION
De acordo com a NT da Sefaz, a tag indAceitacao pode ser preenchida tanto com valores 0 e 1. Com isso a atribuição da tag deve ser feita através do objeto recebido via parâmetro.

Vejamos a documentação da sefaz para o evento 211128:
<img width="1020" height="203" alt="image" src="https://github.com/user-attachments/assets/b992da2b-7593-4e32-8e4d-ef1736f34eab" />

Vejamos a documentação da sefaz para o evento 212110:
<img width="905" height="200" alt="image" src="https://github.com/user-attachments/assets/a2442624-cf1b-4ae1-8986-f780149d481f" />

Vejamos a documentação da sefaz para o evento 212120:
<img width="1020" height="221" alt="image" src="https://github.com/user-attachments/assets/81b242aa-4411-44bf-bbc2-718a722a1fab" />


Ou seja, nesses 3 eventos a tag indAceitacao pode aceitar valores 0 e 1, e seu preenchimento deve ser feito através do valor recebido do objeto.