### PR TITLE
Ajuste para preenchimento da tag tpCredPresIBSZFM

### DIFF
--- a/src/Traits/TraitTagDet.php
+++ b/src/Traits/TraitTagDet.php
@@ -188,7 +188,7 @@ trait TraitTagDet
             "$identificador Código de Benefício Fiscal utilizado pela UF"
         );
         //NT 2025.002_V1.30 - PL_010_V1.30
-        if (!empty($std->tpCredPresIBSZFM) && $this->schema > 9) {
+        if (isset($std->tpCredPresIBSZFM) && $this->schema > 9) {
             $this->dom->addChild(
                 $prod,
                 "tpCredPresIBSZFM",


### PR DESCRIPTION
De acordo com a NT 2025.002-RTC - Versão 1.34, datada de dezembro de 2025, na tag tpCredPresIBSZFM, o valor pode ser 0, indicando "Sem Crédito Presumido". No entanto, durante a criação dessa tag, estava sendo utilizada a função empty() para verificar a existência do atributo tpCredPresIBSZFM, que considera o valor 0 como "vazio", fazendo com que a tag não fosse controlada adequadamente. Fiz a alteração para usar o comando isset(), que resolve esse problema. Após essa melhoria, a tag foi gerada corretamente com o valor apropriado.

<img width="1559" height="339" alt="image" src="https://github.com/user-attachments/assets/37b4142d-ff97-4375-915a-d919623463c5" />

