### PR TITLE
Correção de validação de campo vNFTot zerado

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1264,14 +1264,6 @@ final class Make
                         false,
                         "$identificador Valor total da NF-e com IBS / CBS / IS"
                     );
-                } else {
-                    $this->dom->addChild(
-                        $total,
-                        "vNFTot",
-                        "0.00",
-                        false,
-                        "$identificador Valor total da NF-e com IBS / CBS / IS"
-                    );
                 }
             }
         }


### PR DESCRIPTION
### Problema
Notas de ajuste e complementares podem ser emitidas com valores zerados, como notas complementando apenas impostos, por exemplo. 

Nesse caso, o campo vNFTot deve ficar vazio, o que estava sendo impedido pela validação existente.

### Correção e comprovação
Para corrigir e realizar a emissão dessas notas, essa tag não deve ser informada, já que ao informar um valor zerado (0.00) é retornada uma rejeição de validação de schema. (Rejeicao: Falha no Schema XML da NFe (Elemento:                  enviNFe/NFe[1]/infNFe/total/vNFTot/)). 

Nesse caso, a tag deve ser omitida, como comprovado por testes em homologação e no próprio validador de NFe do portal DFe, como demonstrado nos prints abaixo:

<img width="1746" height="773" alt="2026-01-07_17-07" src="https://github.com/user-attachments/assets/200f6d6a-05f1-4df1-bb51-4373ec260e06" />

<img width="1481" height="719" alt="2026-01-07_17-09" src="https://github.com/user-attachments/assets/3ee5d398-e3a1-44db-98cd-376b59494e18" />

### Validação segundo a NT 2025.02
A NT 2025.002, estabelece uma rejeição 1004 - Rejeição: Valor total da NF-e com IBS / CBS / IS (vNFTot) não informado, porém, esta está com uma observação de implementação futura. 
Até o final de 2026, os valores dos campos vCBS, vIBS e vIS não devem ser somados ao campo vItem, consequentemente, não serão somados no vNFTot. A partir de 2027, notas que possuam apenas o valor desses impostos, terão esses mesmos valores somados no vItem e no vNFTot, somente então será justificável a existência da validação da obrigatoriedade desse campo, até lá, não encontramos nenhuma outra forma além desta para continuar realizando as emissões dessas notas.