### PR TITLE
Remove obrigatoriedade do campo vNFTot

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1264,8 +1264,6 @@ final class Make
                         false,
                         "$identificador Valor total da NF-e com IBS / CBS / IS"
                     );
-                } else {
-                    $this->errors[] = "tag total - O valor de vNFTot não pode ser ZERO.";
                 }
             }
         }


### PR DESCRIPTION
Removida a validação que exigia o preenchimento do campo vNFTot porque a Sefaz aceita NFes sem esse campo informado