### PR TITLE
Ambiente docker e parâmetro para validação na assinatura

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/php/Dockerfile
+      args:
+        USER_ID: ${UID:-1000}
+        GROUP_ID: ${GID:-1000}
+    container_name: sped-nfe-dev
+    working_dir: /var/www/sped-nfe
+    volumes:
+      - ./:/var/www/sped-nfe
+      - composer-cache:/tmp/composer/cache
+      - ./docker/php/conf.d/custom.ini:/usr/local/etc/php/conf.d/99-custom.ini:ro
+    tty: true
+    stdin_open: true
+    command: bash
+
+volumes:
+  composer-cache:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,32 @@
+FROM php:8.3-cli
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_HOME=/tmp/composer
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    unzip \
+    zip \
+    libxml2-dev \
+    libzip-dev \
+    libcurl4-openssl-dev \
+    && docker-php-ext-install -j"$(nproc)" \
+    dom \
+    simplexml \
+    soap \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+RUN groupadd -g "${GROUP_ID}" devuser \
+    && useradd -m -u "${USER_ID}" -g devuser -s /bin/bash devuser
+
+WORKDIR /var/www/sped-nfe
+
+USER devuser
+
+CMD ["bash"]

--- a/docker/php/conf.d/custom.ini
+++ b/docker/php/conf.d/custom.ini
@@ -1,0 +1,2 @@
+memory_limit = 512M
+max_execution_time = 120

--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -364,7 +364,7 @@ class Tools
      * @return string signed NFe xml
      * @throws RuntimeException
      */
-    public function signNFe(string $xml): string
+    public function signNFe(string $xml, int $validXSD = 1): string
     {
         if (empty($xml)) {
             throw new InvalidArgumentException('O argumento xml passado para ser assinado está vazio.');
@@ -392,7 +392,10 @@ class Tools
             $signed = $this->addQRCode($dom);
         }
         //exception will be throw if NFe is not valid
-        $this->isValid($this->versao, $signed, 'nfe');
+        if ($validXSD == 1) {
+            $this->isValid($this->versao, $signed, 'nfe');
+        }
+
         return $signed;
     }
 


### PR DESCRIPTION
- Cria docker/php/Dockerfile com extensões necessárias e Composer;
- Organiza configuração PHP em docker/php/conf.d/custom.ini;
- Atualiza docker-compose.yml para usar novo Dockerfile e montar custom.ini;
- Remove Dockerfile antigo da raiz;
- Ajusta ambiente para evitar erro de memória no PHPStan;
- Adiciona parâmetro para validação de XSD no Tools;