### PR TITLE
update sped common and sped gtin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "nfephp-org/sped-common": "^5.1.0",
-        "nfephp-org/sped-gtin": "^1.1.0",
+        "nfephp-org/sped-common": "dev-master",
+        "nfephp-org/sped-gtin": "dev-master",
         "justinrainbow/json-schema": "^5.2",
         "ext-zlib": "*",
         "ext-dom": "*",


### PR DESCRIPTION
Atualiza as dependências do sped-common e sped-gtin (que também usa o sped-common) para serem compatíveis com CNPJ alfanumérico