### PR TITLE
Implementa NT 2026.002 - DANFE Simplificado Tipo 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Todas as atualizações a partir de 30/05/2016 devem observar os princípios [Ma
 ## Notas da versão:
 Esta release quebra a compatibilidade com as versões anteriores e contêm várias mudanças em relação a forma de configuração e uso.
 ### Added
-- Nothing
+- NT 2026.002 (DANFE Simplificado Tipo 2): tpImp=6 no leiaute (PL_010_V1.30), cStat 120 (autorizado com alerta) em storage/cstat.json e na lista de protocolo de Complements.
 
 ### Deprecated
 - Nothing

--- a/schemes/PL_010_V1.30/leiauteNFe_v4.00.xsd
+++ b/schemes/PL_010_V1.30/leiauteNFe_v4.00.xsd
@@ -138,7 +138,7 @@ Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do e
 									<xs:element name="tpImp">
 										<xs:annotation>
 											<xs:documentation>Formato de impressão do DANFE (0-sem DANFE;1-DANFe Retrato; 2-DANFe Paisagem;3-DANFe Simplificado;
-											4-DANFe NFC-e;5-DANFe NFC-e em mensagem eletrônica)</xs:documentation>
+											4-DANFe NFC-e;5-DANFe NFC-e em mensagem eletrônica;6-DANFe Simplificado Tipo 2 (NT 2026.002, Ajuste SINIEF 13/26))</xs:documentation>
 										</xs:annotation>
 										<xs:simpleType>
 											<xs:restriction base="xs:string">
@@ -149,6 +149,7 @@ Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do e
 												<xs:enumeration value="3"/>
 												<xs:enumeration value="4"/>
 												<xs:enumeration value="5"/>
+												<xs:enumeration value="6"/>
 											</xs:restriction>
 										</xs:simpleType>
 									</xs:element>

--- a/src/Complements.php
+++ b/src/Complements.php
@@ -258,7 +258,8 @@ class Complements
                     //301 Uso denegado por irregularidade fiscal do emitente
                     //302 Uso denegado por irregularidade fiscal do destinatário
                     //303 Uso Denegado Destinatario nao habilitado a operar na UF
-                    $cstatpermit = ['100', '150', '110', '205', '301', '302', '303'];
+                    //120 Autorizado o uso da NF-e, com alerta (NT 2026.002)
+                    $cstatpermit = ['100', '150', '120', '110', '205', '301', '302', '303'];
                     if (!in_array($cStat, $cstatpermit)) {
                         throw DocumentsException::wrongDocument(4, "[$cStat] $xMotivo");
                     }

--- a/storage/cstat.json
+++ b/storage/cstat.json
@@ -74,6 +74,11 @@
         "status": "0",
         "correct": "Conting\u00eancia indispon\u00edvel"
     }, {
+        "cod": "120",
+        "msg": "Autorizado o uso da NF-e, com alerta",
+        "status": "1",
+        "correct": ""
+    }, {
         "cod": "124",
         "msg": "EPEC Autorizado",
         "status": "1",


### PR DESCRIPTION
Suporte minimo para emissao da NF-e mod 55 com DANFE Simplificado Tipo 2 (Ajuste SINIEF 13/26):
