### PR TITLE
Aceita justinrainbow/json-schema ^6.5 além do ^5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": ">= 7.4",
         "nfephp-org/sped-common": "^5.1.0",
         "nfephp-org/sped-gtin": "^1.1.0",
-        "justinrainbow/json-schema": "^5.2",
+        "justinrainbow/json-schema": "^5.2 || ^6.5",
         "ext-zlib": "*",
         "ext-dom": "*",
         "ext-openssl": "*",


### PR DESCRIPTION
## Motivação

Consumidores que precisam de `composer/composer >=2.10.2` (única versão sem advisories de segurança em aberto, ver GHSA-gjfg-22fp-rrxx / GHSA-499r-g7pc-vmp9 entre outras) exigem `justinrainbow/json-schema ^6.5.1` como dependência transitiva. Como o `sped-nfe` fixava `^5.2`, qualquer projeto que precise atualizar o `composer/composer` fica bloqueado por conflito de dependências.

## Mudança

```diff
-        "justinrainbow/json-schema": "^5.2",
+        "justinrainbow/json-schema": "^5.2 || ^6.5",
```

Mantém compatibilidade com quem ainda está em ^5.x e libera quem precisa do ^6.x.

## Validação

Único uso da lib é em `src/Common/Config.php` (`new Validator()`, `check()`, `isValid()`, `getErrors()` lendo a chave `property`) — API idêntica no 6.10.0.

Rodei localmente com `justinrainbow/json-schema` 6.10.0 instalado:
- `composer test`: 779 testes, 2923 assertions — OK
- `composer stan`: sem erros
